### PR TITLE
fix(swift-engineer): use sonnet model and improve macOS app launch

### DIFF
--- a/plugins/swift-engineer/commands/build-and-run.md
+++ b/plugins/swift-engineer/commands/build-and-run.md
@@ -1,7 +1,7 @@
 ---
 description: Build the Xcode project, fix any errors, then run the application
 argument-hint: "[scheme]"
-model: haiku
+model: sonnet
 allowed-tools:
   - Bash
   - Read
@@ -59,7 +59,7 @@ Once the build succeeds, run the app using Bash:
   ```
   Determine the bundle identifier from the project's build settings or `Info.plist`.
 
-- **macOS**: Run the built binary directly from derived data, or use `open` on the `.app` bundle.
+- **macOS**: First kill any running instance of the app (`pkill -x <app-name>`), then remove the old `.app` bundle from `DerivedData/.../Build/Products/Debug/` before building. After the build succeeds, open the fresh `.app` bundle. This avoids launching a stale cached binary.
 
 Report the result to the user.
 
@@ -109,6 +109,6 @@ Once the build succeeds, run the app in the simulator or locally:
   ```
   Determine the bundle identifier from the project's `Info.plist` or build settings.
 
-- **macOS**: Run the built binary directly from derived data, or use `open` on the `.app` bundle.
+- **macOS**: First kill any running instance of the app (`pkill -x <app-name>`), then remove the old `.app` bundle from `DerivedData/.../Build/Products/Debug/` before building. After the build succeeds, open the fresh `.app` bundle. This avoids launching a stale cached binary.
 
 Report the result to the user.


### PR DESCRIPTION
## Summary
- Switch `build-and-run` command model from `haiku` to `sonnet` to prevent "context limit reached" errors when invoking the slash command in longer conversations
- Improve macOS app launch workflow to kill stale instances and remove cached `.app` bundles before rebuilding, avoiding launching stale binaries

## Test plan
- [ ] Run `/build-and-run` in a conversation with substantial context and verify no context limit error
- [ ] Run `/build-and-run` targeting a macOS app and verify it kills the old instance and launches the fresh build