### PR TITLE
feat(swift-engineer): add xctrace CLI profiling support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ This repository doesn't require a build step - it's a collection of markdown-bas
 - **Test plugin locally**: Use `/plugin marketplace add /Users/scott.jungling/Work/sjungling-claude-plugins` to add this marketplace
 - **Install plugin**: Use `/plugin install <plugin-name>@sjungling-plugins` to test installation
 - **Validate agent/command syntax**: Check YAML frontmatter in markdown files is properly formatted
+- **Bump plugin version**: Always increment `version` in `plugins/<plugin-name>/.claude-plugin/plugin.json` when making any changes to a plugin. Claude Code won't detect updates on reinstall without a version bump.
 
 ## Architecture
 

--- a/plugins/swift-engineer/.claude-plugin/plugin.json
+++ b/plugins/swift-engineer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-engineer",
   "description": "Elite iOS and macOS development expertise with automatic skill activation for Swift, SwiftUI, UIKit, Xcode, and Apple frameworks plus code formatting tools",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/swift-engineer/skills/ios-swift-expert/SKILL.md
+++ b/plugins/swift-engineer/skills/ios-swift-expert/SKILL.md
@@ -135,6 +135,44 @@ Optimize for user experience:
 - Use background modes judiciously
 - Profile with Instruments (Energy Log)
 
+**CLI Performance Profiling with xctrace:**
+
+Use `xctrace` to capture Instruments traces from the command line without opening the Instruments GUI. This enables Claude to diagnose performance issues directly.
+
+```bash
+# List available profiling templates
+xctrace list templates
+
+# Record a Time Profiler trace against a running app (by PID or process name)
+xctrace record --template 'Time Profiler' --attach <pid-or-process-name> --output trace.trace --time-limit 10s
+
+# Record against a launched process
+xctrace record --template 'Time Profiler' --launch -- /path/to/app --args
+
+# Record with Allocations template for memory profiling
+xctrace record --template 'Allocations' --attach <pid-or-process-name> --output alloc.trace --time-limit 10s
+
+# Record on a specific device (simulator or physical)
+xctrace record --template 'Time Profiler' --device <device-name-or-udid> --attach <process> --output trace.trace
+
+# Export trace data to XML for analysis
+xctrace export --input trace.trace --xpath '/trace-toc/run[@number="1"]/data/table[@schema="time-profile"]'
+
+# List available devices
+xctrace list devices
+```
+
+Key templates for common scenarios:
+- **Time Profiler**: CPU usage, hot code paths, main thread stalls
+- **Allocations**: Memory usage, allocation patterns, leaks
+- **Leaks**: Detect retain cycles and leaked objects
+- **SwiftUI**: View body evaluations and redraw frequency (Xcode 15+)
+- **Animation Hitches**: Dropped frames and rendering stalls
+- **Network**: HTTP request timing and payload sizes
+- **Energy Log**: Battery drain and power-intensive operations
+
+See `./references/debugging-strategies.md` for detailed xctrace workflows.
+
 ### 5. Apple Platform Best Practices
 
 Follow Apple's official guidelines for:

--- a/plugins/swift-engineer/skills/ios-swift-expert/references/debugging-strategies.md
+++ b/plugins/swift-engineer/skills/ios-swift-expert/references/debugging-strategies.md
@@ -18,6 +18,68 @@ Comprehensive debugging techniques for iOS and macOS development.
 4. **Memory Graph**: Detect retain cycles with Debug → Memory Graph
 5. **Instruments**: Profile with Time Profiler, Allocations, Leaks
 
+## Performance Profiling with xctrace
+
+`xctrace` is the CLI interface for Instruments — use it to capture and analyze performance traces without opening the Instruments GUI.
+
+### Discovery
+
+```bash
+# List all available profiling templates
+xctrace list templates
+
+# List connected devices and simulators
+xctrace list devices
+```
+
+### Recording Traces
+
+```bash
+# Attach to a running process by name or PID
+xctrace record --template 'Time Profiler' --attach MyApp --output perf.trace --time-limit 10s
+
+# Launch and profile a process
+xctrace record --template 'Time Profiler' --launch -- /path/to/MyApp.app/Contents/MacOS/MyApp
+
+# Profile on a specific simulator
+xctrace record --template 'Allocations' --device 'iPhone 16 Pro Simulator' --attach MyApp --output mem.trace --time-limit 15s
+
+# Target a physical device by UDID
+xctrace record --template 'Leaks' --device <udid> --attach MyApp --output leaks.trace --time-limit 20s
+```
+
+### Exporting and Analyzing Trace Data
+
+```bash
+# View the table of contents (available tables/schemas)
+xctrace export --input perf.trace --toc
+
+# Export a specific table to XML
+xctrace export --input perf.trace --xpath '/trace-toc/run[@number="1"]/data/table[@schema="time-profile"]'
+
+# Export to HAR format (network traces)
+xctrace export --input network.trace --har
+```
+
+### Template Selection Guide
+
+| Symptom | Template | What to look for |
+|---------|----------|-----------------|
+| App feels slow / UI stutters | Time Profiler | Hot code paths, main thread time |
+| High memory usage | Allocations | Allocation growth, transient spikes |
+| Memory keeps growing | Leaks | Leaked objects, retain cycles |
+| Dropped frames / jank | Animation Hitches | Commit/render phase durations |
+| SwiftUI views redrawing too often | SwiftUI | Body evaluation counts |
+| Excessive network calls | Network | Request frequency, payload sizes |
+| Battery drain | Energy Log | CPU/GPU/network energy impact |
+
+### Workflow Tips
+
+- Use `--time-limit` to cap trace duration and keep file sizes manageable
+- Combine with `xcodebuild test` to profile during test execution
+- Export XML output and parse with `xmllint` or `xpath` for automated analysis
+- Trace files (`.trace`) can also be opened in Instruments GUI for visual inspection
+
 ## SwiftUI Debugging
 
 1. **Preview Crashes**: Check `PreviewProvider` initialization


### PR DESCRIPTION
## Summary

- Add `xctrace` CLI performance profiling guidance to the `ios-swift-expert` skill, enabling Claude to capture Instruments traces (Time Profiler, Allocations, Leaks, etc.) directly from the command line
- Add detailed xctrace reference to `debugging-strategies.md` with discovery, recording, exporting workflows, and a symptom-to-template selection guide
- Add version bump reminder to CLAUDE.md development commands
- Bump swift-engineer plugin version to 3.7.0

## Test plan

- [ ] Reinstall swift-engineer plugin and verify new version is detected
- [ ] Confirm skill activates when discussing Swift performance topics
- [ ] Verify xctrace commands are syntactically correct by running `xctrace list templates`