### PR TITLE
feat(swift-engineer): add xctrace profiling and scope cache cleanup

### DIFF
--- a/plugins/swift-engineer/.claude-plugin/plugin.json
+++ b/plugins/swift-engineer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-engineer",
   "description": "Elite iOS and macOS development expertise with automatic skill activation for Swift, SwiftUI, UIKit, Xcode, and Apple frameworks plus code formatting tools",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/swift-engineer/skills/ios-swift-expert/references/debugging-strategies.md
+++ b/plugins/swift-engineer/skills/ios-swift-expert/references/debugging-strategies.md
@@ -4,11 +4,19 @@ Comprehensive debugging techniques for iOS and macOS development.
 
 ## Xcode Build Issues
 
-1. **Clean Build Folder**: Product → Clean Build Folder (Cmd+Shift+K)
-2. **Delete Derived Data**: `rm -rf ~/Library/Developer/Xcode/DerivedData`
-3. **Check Build Settings**: Verify code signing, Swift version, deployment target
-4. **Read Error Carefully**: Xcode errors often include fix-its
-5. **Check Dependencies**: Swift Package Manager, CocoaPods, or Carthage issues
+1. **Read Error Carefully**: Xcode errors often include fix-its — address the actual error before clearing caches
+2. **Check Build Settings**: Verify code signing, Swift version, deployment target
+3. **Check Dependencies**: Swift Package Manager, CocoaPods, or Carthage issues
+4. **Clean Project-Scoped Build Cache** (escalate in order):
+   - `xcodebuild clean` — clears build products for the current scheme only
+   - Delete the project-specific derived data folder, not the global one:
+     ```bash
+     # Find the project's derived data subfolder
+     xcodebuild -project YourProject.xcodeproj -showBuildSettings | grep -m1 BUILD_DIR
+     # Delete only that project's derived data (parent of Build/Products)
+     rm -rf /path/to/DerivedData/YourProject-<hash>
+     ```
+   - **Never run `rm -rf ~/Library/Developer/Xcode/DerivedData`** — this nukes caches for all projects and breaks concurrent builds
 
 ## Runtime Issues
 


### PR DESCRIPTION
## Summary

- Add `xctrace` CLI performance profiling guidance to the `ios-swift-expert` skill, enabling Claude to capture Instruments traces (Time Profiler, Allocations, Leaks, etc.) directly from the command line
- Add detailed xctrace reference to `debugging-strategies.md` with discovery, recording, exporting workflows, and a symptom-to-template selection guide
- Replace blanket `rm -rf ~/Library/Developer/Xcode/DerivedData` with project-scoped cache clearing to avoid breaking concurrent builds
- Add version bump reminder to CLAUDE.md development commands
- Bump swift-engineer plugin version to 3.7.1

## Test plan

- [ ] Reinstall swift-engineer plugin and verify new version is detected
- [ ] Confirm skill activates when discussing Swift performance topics
- [ ] Verify xctrace commands are syntactically correct by running `xctrace list templates`
- [ ] Confirm concurrent builds are not disrupted by cache cleanup guidance