### PR TITLE
feat(workflow): add /spotlight command for worktree-to-main testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Each plugin can contain:
 - Skill: `git-bisect-debugging` - Systematic workflow for using git bisect to identify which commit introduced a bug. Supports automated test scripts, manual verification, and hybrid approaches with subagent architecture for isolated execution. Integrates with superpowers:systematic-debugging for root cause analysis.
 
 **workflow** (`plugins/workflow/`):
+- Command: `/spotlight [on|off|status]` - Spotlight worktree changes into main worktree for testing (like Conductor Spotlight). Merges committed worktree changes via `git merge --no-commit` so you can test in the main worktree's environment, then cleanly abort when done.
 - Command: `/review-unstaged` - Review unstaged changes for code quality, style, and potential issues
 
 **data-tools** (`plugins/data-tools/`):

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "workflow",
-  "description": "Code review commands for analyzing unstaged changes",
-  "version": "2.4.0",
+  "description": "Code review and worktree workflow commands",
+  "version": "2.5.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"
   },
   "license": "MIT",
-  "keywords": ["code-review", "workflow", "git", "quality"]
+  "keywords": ["code-review", "workflow", "git", "quality", "worktree", "spotlight", "testing"]
 }

--- a/plugins/workflow/commands/spotlight.md
+++ b/plugins/workflow/commands/spotlight.md
@@ -1,0 +1,84 @@
+---
+description: Spotlight worktree changes into main worktree for testing (like Conductor Spotlight)
+argument-hint: [on|off|status]
+allowed-tools:
+  - Bash(git:*)
+---
+
+Spotlight testing: merge worktree changes into the main worktree without committing,
+so you can test in the main worktree's environment (build artifacts, node_modules, databases, etc.).
+
+Parse `$ARGUMENTS` for the mode: `on` (default if empty), `off`, or `status`.
+
+## Step 1: Detect Environment
+
+Run these commands:
+
+!`git rev-parse --show-toplevel`
+!`git worktree list`
+!`git branch --show-current`
+!`git status --porcelain`
+
+Determine:
+- **Current worktree path** and **main worktree path** (first entry in `git worktree list`)
+- **Is this a linked worktree?** — current directory is NOT the main worktree
+- **Current branch name**
+- **Has uncommitted changes?**
+
+If NOT in a linked worktree, abort with:
+> "Spotlight requires a linked worktree. Run this from a Claude Code worktree, not the main repo."
+
+## Step 2: Execute Mode
+
+### Mode: `on` (default)
+
+1. **Check main worktree state:**
+   - Run `git -C <main-worktree-path> status --porcelain`
+   - If dirty, abort: "Main worktree has uncommitted changes. Commit or stash them first."
+   - Check for active merge: look for MERGE_HEAD in the main worktree's git directory.
+     For a standard (non-bare) main worktree, check `<main-worktree-path>/.git/MERGE_HEAD`.
+     If an active merge exists, abort: "Main worktree already has an active merge. Run `/spotlight off` first."
+
+2. **Checkpoint uncommitted changes (if any):**
+   - If `git status --porcelain` shows changes:
+     - `git add -A`
+     - `git commit -m "spotlight: checkpoint"`
+     - Remember we created a checkpoint commit (report this to user)
+   - If no changes, skip this step
+
+3. **Merge into main worktree:**
+   - Get current branch name: `<branch>`
+   - `git -C <main-worktree-path> merge --no-commit --no-ff <branch>`
+   - The `--no-ff` ensures we get a proper staging even if fast-forward is possible
+
+4. **Handle result:**
+   - **Success**: Report that changes are now staged in main worktree. Remind user:
+     - Test in main worktree at `<main-worktree-path>`
+     - Run `/spotlight off` when done to clean up
+   - **Conflicts**: Report conflicting files. User can resolve in main worktree or
+     run `/spotlight off` to abort
+
+### Mode: `off`
+
+1. **Abort merge in main worktree:**
+   - Check if main worktree has an active merge (check for MERGE_HEAD as described above)
+   - If yes: `git -C <main-worktree-path> merge --abort`
+   - If no active merge: inform user "No active spotlight session found in main worktree"
+
+2. **Undo checkpoint commit (if applicable):**
+   - Check if HEAD commit message is "spotlight: checkpoint"
+     via `git log -1 --format=%s`
+   - If yes: `git reset --soft HEAD~1` to restore working state
+   - If no: skip (user may have made additional commits)
+
+3. **Report**: Confirm cleanup is complete
+
+### Mode: `status`
+
+1. Check main worktree for active merge (MERGE_HEAD)
+2. Check if current worktree HEAD is a spotlight checkpoint
+3. Report:
+   - Whether spotlight is active
+   - Which branch is spotlighted
+   - Main worktree path
+   - Whether a checkpoint commit exists


### PR DESCRIPTION
## Summary

- Adds `/spotlight [on|off|status]` command to the workflow plugin, inspired by Conductor's Spotlight Testing
- Merges worktree changes into the main worktree via `git merge --no-commit --no-ff`, enabling testing in the main worktree's environment (build artifacts, node_modules, databases, etc.)
- Supports automatic checkpoint commits for uncommitted work and clean `merge --abort` cleanup
- Bumps workflow plugin to v2.5.0

## Test plan

- [ ] Install plugin via `/plugin install workflow@sjungling-plugins`
- [ ] From a linked worktree, run `/spotlight on` and verify changes appear in main worktree
- [ ] Run `/spotlight status` and confirm it reports active spotlight
- [ ] Run `/spotlight off` and verify main worktree is restored and checkpoint commit is undone
- [ ] Verify `/spotlight on` from main worktree (not a linked worktree) aborts with error