### PR TITLE
fix(swift-engineer): resolve build products dir to avoid stale binaries

### DIFF
--- a/plugins/swift-engineer/.claude-plugin/plugin.json
+++ b/plugins/swift-engineer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-engineer",
   "description": "Elite iOS and macOS development expertise with automatic skill activation for Swift, SwiftUI, UIKit, Xcode, and Apple frameworks plus code formatting tools",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/swift-engineer/commands/build-and-run.md
+++ b/plugins/swift-engineer/commands/build-and-run.md
@@ -74,20 +74,34 @@ Report the result to the user.
 3. Determine the available schemes by running: `xcodebuild -list -workspace <workspace>` or `xcodebuild -list -project <project>`
 4. If multiple schemes exist, use AskUserQuestion to ask which scheme to build and run
 
-### Step 2: Build the Project
+### Step 2: Resolve the Build Products Directory
 
-Run the build using `xcodebuild`:
+Before building, determine the exact output path using `-showBuildSettings`. This avoids launching a stale binary from a different DerivedData directory:
+
+```bash
+# For macOS:
+BUILT_PRODUCTS_DIR=$(xcodebuild -project <project> -scheme <scheme> -configuration Debug -showBuildSettings -skipMacroValidation -destination 'platform=macOS' 2>/dev/null | grep ' BUILT_PRODUCTS_DIR =' | awk '{print $3}')
+
+# For iOS:
+BUILT_PRODUCTS_DIR=$(xcodebuild -project <project> -scheme <scheme> -configuration Debug -showBuildSettings -skipMacroValidation -destination "platform=iOS Simulator,name=$SIMULATOR" 2>/dev/null | grep ' BUILT_PRODUCTS_DIR =' | awk '{print $3}')
+```
+
+Save this path — you will use it in Step 4 to launch the correct binary.
+
+### Step 3: Build the Project
+
+Run the build using `xcodebuild`. For iOS, determine the simulator first:
 
 ```
 SIMULATOR=$(xcrun simctl list devices available -j | python3 -c "import sys,json; devs=[d for r in json.load(sys.stdin)['devices'].values() for d in r if d['isAvailable']]; iphones=[d for d in devs if 'iPhone' in d['name']]; print(iphones[-1]['name'] if iphones else devs[0]['name'] if devs else '')")
 xcodebuild -workspace <workspace> -scheme <scheme> -destination "platform=iOS Simulator,name=$SIMULATOR" build 2>&1 | tail -50
 ```
 
-Adjust the destination as appropriate for the project type (iOS, macOS, etc.). For macOS apps, omit the `-destination` flag.
+Adjust the destination as appropriate for the project type (iOS, macOS, etc.). For macOS apps, use `-destination 'platform=macOS'`.
 
 If using a `.xcodeproj` instead of a workspace, use `-project` instead of `-workspace`.
 
-### Step 3: Fix Build Errors
+### Step 4: Fix Build Errors
 
 If the build fails:
 
@@ -98,17 +112,20 @@ If the build fails:
 
 Prioritize errors over warnings. If warnings remain after a clean build, briefly note them to the user.
 
-### Step 4: Run the Application
+### Step 5: Run the Application
 
-Once the build succeeds, run the app in the simulator or locally:
+Once the build succeeds, use the `BUILT_PRODUCTS_DIR` from Step 2 to launch the exact binary that was just built:
 
-- **iOS/iPadOS**: Determine the best available simulator dynamically, then boot and launch:
+- **iOS/iPadOS**: Boot the simulator and launch:
   ```
-  SIMULATOR=$(xcrun simctl list devices available -j | python3 -c "import sys,json; devs=[d for r in json.load(sys.stdin)['devices'].values() for d in r if d['isAvailable']]; iphones=[d for d in devs if 'iPhone' in d['name']]; print(iphones[-1]['name'] if iphones else devs[0]['name'] if devs else '')")
   xcrun simctl boot "$SIMULATOR" 2>/dev/null; xcrun simctl launch --terminate-running-process --console-stdout booted <bundle-identifier>
   ```
   Determine the bundle identifier from the project's `Info.plist` or build settings.
 
-- **macOS**: First kill any running instance of the app (`pkill -x <app-name>`), then remove the old `.app` bundle from `DerivedData/.../Build/Products/Debug/` before building. After the build succeeds, open the fresh `.app` bundle. This avoids launching a stale cached binary.
+- **macOS**: First kill any running instance of the app (`pkill -x <app-name>`), then open the `.app` from the resolved build products directory:
+  ```bash
+  pkill -x <app-name> 2>/dev/null; sleep 1
+  open "$BUILT_PRODUCTS_DIR/<app-name>.app"
+  ```
 
 Report the result to the user.


### PR DESCRIPTION
## Summary

- Adds a new step to resolve `BUILT_PRODUCTS_DIR` via `-showBuildSettings` before building, ensuring the run step launches the exact binary that was just compiled
- Eliminates stale binary launches caused by DerivedData directory mismatches on macOS
- Bumps plugin version to 3.9.0

## Test plan

- [ ] Run `/build-and-run` on a macOS project and verify the correct binary launches
- [ ] Run `/build-and-run` on an iOS project and verify simulator launches the freshly built app
- [ ] Confirm version bump is detected on plugin reinstall