### PR TITLE
feat(workflow): add /create-issue command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Each plugin can contain:
 **workflow** (`plugins/workflow/`):
 - Command: `/spotlight [on|off|status]` - Spotlight worktree changes into main worktree for testing (like Conductor Spotlight). Merges committed worktree changes via `git merge --no-commit` so you can test in the main worktree's environment, then cleanly abort when done.
 - Command: `/review-unstaged` - Review unstaged changes for code quality, style, and potential issues
+- Command: `/create-issue [file-path]` - Create a GitHub issue from session context. Auto-discovers superpowers specs/plans, Claude plan files, or generates a conversation summary. Uses `gh` CLI with `--body-file`.
 
 **data-tools** (`plugins/data-tools/`):
 - Skill: `structured-logging` - Use SQLite for structured data during complex workflows, debugging, and data analysis instead of temp files or stdout parsing. Automatically activates when parsing large output (>100 lines), tracking state across operations, correlating events, or analyzing structured data. Databases stored in `~/.claude-logs/<project-name>.db` persist across sessions.

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Code review and worktree workflow commands",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/workflow/commands/create-issue.md
+++ b/plugins/workflow/commands/create-issue.md
@@ -1,0 +1,133 @@
+---
+description: Create a GitHub issue from session context (specs, plans, or conversation summary)
+argument-hint: "[file-path]"
+model: sonnet
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+---
+
+Create a GitHub issue using the best available content from the current session.
+
+Parse `$ARGUMENTS` for an optional file path override.
+
+## Step 1: Discover Content
+
+Run the discovery script to find the best content source. The script is located relative to this command file:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "$0")/../scripts" 2>/dev/null && pwd || echo "")"
+```
+
+If `$SCRIPT_DIR` is empty or the script does not exist, compute the path from the plugin root. The script lives at `plugins/workflow/scripts/discover-issue-content.sh` relative to the marketplace root. As a fallback, use `${CLAUDE_PLUGIN_ROOT}/scripts/discover-issue-content.sh` if that variable is available.
+
+Run the script, passing `$ARGUMENTS` if non-empty:
+
+```bash
+DISCOVERY=$(bash "$SCRIPT_DIR/discover-issue-content.sh" $ARGUMENTS 2>&1)
+```
+
+If the script exits non-zero, check stderr for `{"error": "..."}` and report the error to the user. Common errors:
+- `gh CLI not installed` — tell user to install GitHub CLI
+- `jq not installed` — tell user to install jq
+- `not in a git repository` — abort
+- `file not found: <path>` — abort with the missing file path
+
+Parse the JSON output:
+
+```bash
+SOURCE=$(echo "$DISCOVERY" | jq -r '.source')
+PRIMARY=$(echo "$DISCOVERY" | jq -r '.primary')
+SECONDARY=$(echo "$DISCOVERY" | jq -r '.secondary')
+LABEL=$(echo "$DISCOVERY" | jq -r '.label')
+REPO=$(echo "$DISCOVERY" | jq -r '.repo')
+SPECS=$(echo "$DISCOVERY" | jq -r '.candidates.specs[]' 2>/dev/null)
+PLANS=$(echo "$DISCOVERY" | jq -r '.candidates.plans[]' 2>/dev/null)
+```
+
+## Step 2: Resolve Content
+
+Based on the `SOURCE` value:
+
+### `explicit` or `claude-plan`
+`PRIMARY` already points to the file. Use it directly as `$BODY_FILE`.
+
+### `superpowers`
+If `PRIMARY` is non-empty, use it as `$BODY_FILE`.
+
+If `PRIMARY` is empty, there are multiple candidates that need disambiguation. Use `AskUserQuestion` to present the candidates from `SPECS` and/or `PLANS` and ask which file to use as the issue body. Set `$BODY_FILE` to the chosen file.
+
+If `SECONDARY` is non-empty, it will be posted as a comment after issue creation.
+
+### `summary`
+No content files were found. Write a markdown summary of the current conversation covering:
+- **Problem statement** — what prompted the session
+- **Approach discussed** — key technical decisions and alternatives considered
+- **Current status** — what was accomplished, what remains
+- **Open questions** — anything unresolved
+
+Write the summary to a temp file:
+```bash
+BODY_FILE=$(mktemp /tmp/gh-issue-body-XXXXXX.md)
+```
+
+## Step 3: Validate Content Size
+
+Check the byte count of `$BODY_FILE`:
+```bash
+wc -c < "$BODY_FILE"
+```
+
+If it exceeds 60000 bytes:
+1. Read the file and find the last markdown heading (`## ` or `### `) boundary before the 60000 byte mark
+2. Truncate at that boundary
+3. Append: `\n\n---\n_Content truncated due to GitHub size limits. Full document: \`<original-path>\`_`
+4. Write the truncated version to a new temp file and use that instead
+
+Apply the same size check to `$SECONDARY` if it is non-empty.
+
+## Step 4: Suggest and Confirm Title
+
+Extract a title suggestion from `$BODY_FILE`:
+- Look for the first `# ` (H1) heading in the file
+- If no H1, use the first non-empty, non-frontmatter line
+- Strip any markdown formatting from the title
+
+Use `AskUserQuestion` to present:
+- Which content source was detected (`SOURCE` value)
+- The file path being used
+- The suggested title
+- Ask the user to confirm the title or provide a different one
+
+## Step 5: Create the Issue
+
+Build the label flag from the discovery output:
+- If `LABEL` is non-empty, use `--label "$LABEL"`
+- Otherwise, omit `--label`
+
+```bash
+gh issue create --title "<confirmed-title>" --body-file "$BODY_FILE" --label "$LABEL"
+```
+
+Capture the output — `gh` prints the issue URL on success.
+
+## Step 6: Post Secondary Content
+
+If `SECONDARY` is non-empty:
+
+1. Extract the issue number from the URL: `echo "$ISSUE_URL" | grep -o '[0-9]*$'`
+2. Post the secondary content as a comment:
+   ```bash
+   gh issue comment "$ISSUE_NUMBER" --body-file "$SECONDARY"
+   ```
+
+## Step 7: Cleanup and Report
+
+Remove any temp files that were created (do NOT remove the original source files).
+
+Report to the user:
+- The issue URL (as a clickable link)
+- Which content source was used (`SOURCE`)
+- Which label was applied (if any)
+- Whether secondary content was added as a comment

--- a/plugins/workflow/scripts/discover-issue-content.sh
+++ b/plugins/workflow/scripts/discover-issue-content.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# discover-issue-content.sh
+#
+# Discovers the best content source for creating a GitHub issue from
+# the current Claude Code session. Outputs JSON to stdout.
+#
+# Usage: discover-issue-content.sh [explicit-file-path]
+#
+# Output JSON shape:
+#   {
+#     "source": "explicit" | "superpowers" | "claude-plan" | "summary",
+#     "primary": "/path/to/file.md" | "",
+#     "secondary": "/path/to/file.md" | "",
+#     "candidates": { "specs": [...], "plans": [...] },
+#     "label": "research" | "enhancement" | "",
+#     "repo": "owner/repo" | ""
+#   }
+#
+# Exit codes:
+#   0 — success (check "source" field for what was found)
+#   1 — not in a git repo or gh not available
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+# --- Helpers ---
+
+json_output() {
+  local source="$1" primary="$2" secondary="${3:-}" specs_json="${4:-[]}" plans_json="${5:-[]}" label="${6:-}" repo="${7:-}"
+  jq -n \
+    --arg source "$source" \
+    --arg primary "$primary" \
+    --arg secondary "$secondary" \
+    --argjson specs "$specs_json" \
+    --argjson plans "$plans_json" \
+    --arg label "$label" \
+    --arg repo "$repo" \
+    '{
+      source: $source,
+      primary: $primary,
+      secondary: $secondary,
+      candidates: { specs: $specs, plans: $plans },
+      label: $label,
+      repo: $repo
+    }'
+}
+
+detect_label() {
+  local labels
+  labels=$(gh label list --json name -q '.[].name' 2>/dev/null || echo "")
+  if echo "$labels" | grep -qx "research"; then
+    echo "research"
+  elif echo "$labels" | grep -qx "enhancement"; then
+    echo "enhancement"
+  else
+    echo ""
+  fi
+}
+
+detect_repo() {
+  gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo ""
+}
+
+# Collect file paths into a JSON array
+files_to_json_array() {
+  local dir="$1"
+  if [[ -d "$dir" ]]; then
+    local files
+    files=$(find "$dir" -maxdepth 1 -name '*.md' -type f 2>/dev/null | sort -r)
+    if [[ -n "$files" ]]; then
+      echo "$files" | jq -R . | jq -s .
+      return
+    fi
+  fi
+  echo "[]"
+}
+
+# --- Pre-checks ---
+
+if ! command -v gh &>/dev/null; then
+  echo '{"error": "gh CLI not installed"}' >&2
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo '{"error": "jq not installed"}' >&2
+  exit 1
+fi
+
+if [[ -z "$REPO_ROOT" ]]; then
+  echo '{"error": "not in a git repository"}' >&2
+  exit 1
+fi
+
+# --- Detect label and repo (shared across all paths) ---
+
+LABEL=$(detect_label)
+REPO=$(detect_repo)
+
+# --- Waterfall ---
+
+# 1. Explicit file argument
+if [[ $# -ge 1 && -n "$1" ]]; then
+  EXPLICIT_FILE="$1"
+  if [[ -f "$EXPLICIT_FILE" ]]; then
+    json_output "explicit" "$EXPLICIT_FILE" "" "[]" "[]" "$LABEL" "$REPO"
+    exit 0
+  else
+    echo "{\"error\": \"file not found: $EXPLICIT_FILE\"}" >&2
+    exit 1
+  fi
+fi
+
+# 2. Superpowers specs/plans
+SPECS_DIR="$REPO_ROOT/docs/superpowers/specs"
+PLANS_DIR="$REPO_ROOT/docs/superpowers/plans"
+
+SPECS_JSON=$(files_to_json_array "$SPECS_DIR")
+PLANS_JSON=$(files_to_json_array "$PLANS_DIR")
+
+SPEC_COUNT=$(echo "$SPECS_JSON" | jq 'length')
+PLAN_COUNT=$(echo "$PLANS_JSON" | jq 'length')
+
+if [[ "$SPEC_COUNT" -gt 0 || "$PLAN_COUNT" -gt 0 ]]; then
+  PRIMARY=""
+  SECONDARY=""
+
+  if [[ "$SPEC_COUNT" -eq 1 ]]; then
+    PRIMARY=$(echo "$SPECS_JSON" | jq -r '.[0]')
+  elif [[ "$SPEC_COUNT" -gt 1 ]]; then
+    # Multiple specs — leave primary empty, let caller disambiguate from candidates
+    PRIMARY=""
+  fi
+
+  if [[ "$PLAN_COUNT" -ge 1 && -n "$PRIMARY" ]]; then
+    # Spec is primary, most recent plan is secondary
+    SECONDARY=$(echo "$PLANS_JSON" | jq -r '.[0]')
+  elif [[ "$SPEC_COUNT" -eq 0 && "$PLAN_COUNT" -eq 1 ]]; then
+    # No specs, single plan is primary
+    PRIMARY=$(echo "$PLANS_JSON" | jq -r '.[0]')
+  elif [[ "$SPEC_COUNT" -eq 0 && "$PLAN_COUNT" -gt 1 ]]; then
+    # No specs, multiple plans — let caller disambiguate
+    PRIMARY=""
+  fi
+
+  json_output "superpowers" "$PRIMARY" "$SECONDARY" "$SPECS_JSON" "$PLANS_JSON" "$LABEL" "$REPO"
+  exit 0
+fi
+
+# 3. Claude plan file via session metadata
+#
+# $PPID inside a script points to the intermediate shell, not Claude Code.
+# Instead, find the session file matching the current working directory by
+# scanning all active session files.
+CLAUDE_DIR="$HOME/.claude"
+CURRENT_CWD="$(pwd)"
+SESSION_ID=""
+
+for sf in "$CLAUDE_DIR/sessions/"*.json; do
+  [[ -f "$sf" ]] || continue
+  sf_cwd=$(jq -r '.cwd // empty' "$sf" 2>/dev/null || echo "")
+  if [[ "$sf_cwd" == "$CURRENT_CWD" ]]; then
+    SESSION_ID=$(jq -r '.sessionId // empty' "$sf" 2>/dev/null || echo "")
+    break
+  fi
+done
+
+if [[ -n "$SESSION_ID" ]]; then
+  ENCODED_CWD=$(echo "$CURRENT_CWD" | tr '/.' '-')
+  JSONL="$CLAUDE_DIR/projects/${ENCODED_CWD}/${SESSION_ID}.jsonl"
+
+  if [[ -f "$JSONL" ]]; then
+    SLUG=$(grep -o '"slug":"[^"]*"' "$JSONL" 2>/dev/null | head -1 | cut -d'"' -f4 || echo "")
+
+    if [[ -n "$SLUG" ]]; then
+      PLAN_FILE="$CLAUDE_DIR/plans/${SLUG}.md"
+
+      if [[ -s "$PLAN_FILE" ]]; then
+        json_output "claude-plan" "$PLAN_FILE" "" "[]" "[]" "$LABEL" "$REPO"
+        exit 0
+      fi
+    fi
+  fi
+fi
+
+# 4. Nothing found — caller should generate a summary
+json_output "summary" "" "" "[]" "[]" "$LABEL" "$REPO"
+exit 0


### PR DESCRIPTION
## Summary

- Add `/create-issue [file-path]` workflow command that creates GitHub issues from session context
- Add `discover-issue-content.sh` bash/jq helper script that handles content discovery waterfall: superpowers specs/plans → Claude plan files → conversation summary fallback
- Script detects labels (`research`/`enhancement`), resolves session metadata via CWD matching, and outputs structured JSON
- Bump workflow plugin version to 2.7.0

## Test plan

- [ ] Install plugin: `/plugin install workflow@sjungling-plugins`
- [ ] Test with explicit file: `/create-issue README.md`
- [ ] Test auto-detection with a Claude plan file present
- [ ] Test summary fallback in a fresh session with no spec/plan
- [ ] Verify discovery script standalone: `plugins/workflow/scripts/discover-issue-content.sh`