### PR TITLE
fix(workflow): use origin/main in rebase-main worktree case

### DIFF
--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Code review and worktree workflow commands",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/workflow/commands/rebase-main.md
+++ b/plugins/workflow/commands/rebase-main.md
@@ -30,10 +30,9 @@ If there are uncommitted changes (staged or unstaged):
 ## Step 3: Rebase based on context
 
 ### Case A: In a worktree
-The main worktree has the authoritative copy of main. Fetch from the main worktree path:
-1. Get the main worktree path (first entry from `git worktree list`)
-2. Run `git fetch <main-worktree-path> main:main` to update the local main ref from the main worktree
-3. Run `git rebase main`
+Fetch the latest main from origin and rebase against it. Do NOT try to update the local `main` ref — git refuses to update a branch that is checked out in another worktree.
+1. Run `git fetch origin main`
+2. Run `git rebase origin/main`
 
 ### Case B: Not in a worktree, ON main branch
 We're on main itself — rebase against origin:


### PR DESCRIPTION
## Summary
- Fix `/rebase-main` always failing on initial attempt when run from a worktree
- The worktree case used `git fetch <path> main:main` which git rejects because the `main` ref is checked out in the main worktree
- Switch to `git fetch origin main` + `git rebase origin/main` to avoid the ref conflict entirely

## Test plan
- [ ] Run `/rebase-main` from a linked worktree and verify it succeeds on first attempt
- [ ] Run `/rebase-main` from the main worktree (Case B/C) to confirm no regression