### PR TITLE
chore(workflow): update monitor-prs to use haiku and delegate to specialized skills

### DIFF
--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Code review and worktree workflow commands",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/workflow/commands/monitor-prs.md
+++ b/plugins/workflow/commands/monitor-prs.md
@@ -1,5 +1,6 @@
 ---
 description: Monitor open PRs — review changes, post comments, resolve conflicts, surface new feedback
+model: haiku
 allowed-tools:
   - Bash
   - Read
@@ -11,6 +12,8 @@ allowed-tools:
 ---
 
 Monitor all open pull requests in the current repository. Designed for recurring use with `/loop` or as a one-shot check.
+
+This command runs on haiku for the main orchestration loop. Expensive review work is delegated to specialized skills that use their own models.
 
 ## Setup
 
@@ -28,50 +31,39 @@ gh pr list --author "@me" --state open --json number,title,headRefName,updatedAt
 
 If no open PRs are found, report that to the user and stop.
 
-## Step 1: Review New or Updated PRs
-
-For each open PR, determine if it needs review by checking whether it has changed since the last monitoring cycle.
+## Step 1: Identify PRs Needing Review
 
 Track review state using a timestamp file at `/tmp/monitor-prs-last-run-{repo-slug}.txt`. If the file exists, read the ISO 8601 timestamp from it. If it does not exist, treat all PRs as needing review.
 
-For each PR whose `updatedAt` is newer than the last-run timestamp (or all PRs on the first run):
+Partition the PRs into two lists:
 
-1. Check out the PR diff:
-   ```bash
-   gh pr diff {number}
-   ```
-2. Review the diff for code quality issues, bugs, style problems, and improvement opportunities. For each finding, record:
-   - **File path** (relative to repo root)
-   - **Line number(s)** in the new version
-   - **Issue description** with rationale
-   - **Confidence score** (0-100) indicating how certain you are this is a real issue
+- **Needs review**: PRs whose `updatedAt` is newer than the last-run timestamp (or all PRs on the first run)
+- **Unchanged**: PRs that have not been updated since the last run
 
-Do NOT post comments yet — collect all findings first.
+## Step 2: Review New or Updated PRs
 
-## Step 2: Validate Review Comments
+For each PR that needs review, invoke the `/pr-review-toolkit:review-pr` skill using the `Skill` tool:
 
-Filter the collected findings from Step 1:
-
-1. Discard any finding with a confidence score below **60**
-2. For each remaining finding, verify the issue still applies:
-   - Read the actual file at the referenced line to confirm the code matches the diff
-   - Check that the issue is not already addressed elsewhere in the PR
-   - Confirm the comment is actionable and specific
-3. Discard any finding that fails validation
-
-If no findings survive validation, skip to Step 4.
-
-## Step 3: Post Valid Comments
-
-For each PR that has validated findings, use the `/workflow:post-pr-comments` skill to post them as a pull request review.
-
-Invoke the skill once per PR, switching to the PR's branch context first:
-
-```bash
-git fetch origin {headRefName}
+```
+Skill: "pr-review-toolkit:review-pr"
+Args: "{number}"
 ```
 
-The skill will handle formatting and posting via the GitHub API.
+This delegates the full code review (diff analysis, finding issues, confidence scoring, validation) to the specialized review toolkit, which uses its own model and agent pipeline.
+
+Wait for the review to complete before proceeding. The skill will produce validated review findings.
+
+## Step 3: Post Review Comments
+
+If the review from Step 2 produced any findings, use the `/workflow:post-pr-comments` skill to post them on the PR:
+
+```
+Skill: "workflow:post-pr-comments"
+```
+
+Invoke the skill once per PR that has findings. The skill handles formatting comments, resolving line numbers, and posting via the GitHub API.
+
+If no findings were produced, skip to Step 4.
 
 ## Step 4: Check for Merge Conflicts
 

--- a/plugins/workflow/commands/monitor-prs.md
+++ b/plugins/workflow/commands/monitor-prs.md
@@ -7,6 +7,7 @@ allowed-tools:
   - Write
   - Grep
   - Glob
+  - Edit
   - Agent
   - Skill
 ---
@@ -35,10 +36,7 @@ If no open PRs are found, report that to the user and stop.
 
 Track review state using a timestamp file at `/tmp/monitor-prs-last-run-{repo-slug}.txt`. If the file exists, read the ISO 8601 timestamp from it. If it does not exist, treat all PRs as needing review.
 
-Partition the PRs into two lists:
-
-- **Needs review**: PRs whose `updatedAt` is newer than the last-run timestamp (or all PRs on the first run)
-- **Unchanged**: PRs that have not been updated since the last run
+Filter to PRs whose `updatedAt` is newer than the last-run timestamp (or all PRs on the first run). Skip unchanged PRs for review, but still include them in conflict and comment checks (Steps 4-5).
 
 ## Step 2: Review New or Updated PRs
 


### PR DESCRIPTION
## Summary

- Run `/monitor-prs` main orchestration loop on haiku model for cost efficiency
- Delegate PR review to `/pr-review-toolkit:review-pr` instead of inline diff analysis
- Use `/workflow:post-pr-comments` skill invocation for posting review findings

## Test plan

- [ ] Run `/monitor-prs` against a repo with open PRs and verify haiku model is used
- [ ] Confirm `/pr-review-toolkit:review-pr` is invoked for new/updated PRs
- [ ] Confirm `/workflow:post-pr-comments` posts findings correctly
- [ ] Verify unchanged PRs are skipped