### PR TITLE
feat(workflow): add /review-and-fix command and session-context hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ Each plugin can contain:
 - Command: `/create-issue [file-path]` - Create a GitHub issue from session context. Auto-discovers superpowers specs/plans, Claude plan files, or generates a conversation summary. Uses `gh` CLI with `--body-file`.
 - Command: `/post-pr-comments` - Post inline code review comments from conversation onto the current branch's PR. Writes a comments JSON file, then uses `gh api` to post a pull request review with targeted line comments.
 - Command: `/monitor-prs` - Monitor open PRs on a recurring basis: review changes, post validated comments, resolve merge conflicts in worktrees, and surface new reviewer feedback. Designed for use with `/loop` (e.g., `/loop 5m /monitor-prs`).
+- Command: `/review-and-fix [pr-number]` - Run a review-and-fix cycle on an existing PR: dispatches a code-review subagent, applies high-confidence fixes (>=80), runs build verification, asks for confirmation, then commits and pushes. Mandatory build gate before commit.
+- Hook: SessionStart - Emits worktree context (cwd, git toplevel, branch, worktree detection) so subagents stay in the correct working tree and don't accidentally edit the main repo.
 
 **data-tools** (`plugins/data-tools/`):
 - Skill: `structured-logging` - Use SQLite for structured data during complex workflows, debugging, and data analysis instead of temp files or stdout parsing. Automatically activates when parsing large output (>100 lines), tracking state across operations, correlating events, or analyzing structured data. Databases stored in `~/.claude-logs/<project-name>.db` persist across sessions.

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Code review and worktree workflow commands",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/workflow/commands/review-and-fix.md
+++ b/plugins/workflow/commands/review-and-fix.md
@@ -1,0 +1,157 @@
+---
+description: Review a PR, apply high-confidence fixes, verify build, and push
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Agent
+---
+
+Run a review-and-fix cycle on a pull request. The PR must already exist. If a PR number is provided as an argument, use it; otherwise use the PR associated with the current branch.
+
+## Step 1: Resolve PR Context
+
+Determine which PR to work on:
+
+```bash
+# If $ARGUMENTS is set, use it as the PR number; otherwise resolve from current branch
+PR_NUMBER="${ARGUMENTS:-}"
+if [ -z "$PR_NUMBER" ]; then
+    PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+fi
+```
+
+If no PR can be resolved, tell the user and stop. Do not try to open a PR — this command is fix-only.
+
+Fetch PR metadata to confirm the target:
+
+```bash
+gh pr view "$PR_NUMBER" --json number,title,headRefName,baseRefName,state,mergeable
+```
+
+Confirm the PR is open. If it is merged or closed, stop and report.
+
+Check that the current working tree matches the PR's `headRefName`. If not, tell the user and stop — do not switch branches automatically, since the user may have unsaved work or be in a specific worktree. Tell them the command required branch and let them switch.
+
+## Step 2: Dispatch Review Subagent
+
+Use the `Agent` tool to run a code review in a subagent. This keeps the raw diff output out of the main context and isolates the review findings.
+
+Agent prompt template:
+
+```
+Review PR #<number> in the current repository. The head branch is <headRefName>
+and the base is <baseRefName>.
+
+1. Get the diff with: gh pr diff <number>
+2. Analyze every changed hunk for:
+   - Bugs and logic errors
+   - Missing error handling on system-boundary calls
+   - Style violations against project conventions (read CLAUDE.md if present)
+   - Missing tests for new behavior
+   - Performance regressions on hot paths
+   - Accessibility issues in view code (if the project has accessibility rules)
+3. For each finding, return a JSON object:
+   {
+     "path": "relative/path.ext",
+     "line": 42,
+     "confidence": 0-100,
+     "category": "bug|style|test|perf|a11y|other",
+     "description": "What is wrong",
+     "suggested_fix": "Concrete change to make (code snippet or instruction)"
+   }
+4. Return a JSON array of findings. If nothing is wrong, return [].
+
+Be strict about confidence scoring. Only score >= 80 for issues you are certain
+are real bugs or clear policy violations. Score 60-79 for likely-but-not-certain
+issues. Score below 60 for subjective preferences — these will be discarded.
+```
+
+Capture the agent's returned JSON array as `$FINDINGS`.
+
+## Step 3: Filter and Report
+
+Parse `$FINDINGS` and split into three buckets:
+
+- **Auto-fix**: confidence >= 80 — will be fixed in Step 4
+- **Ask user**: confidence 60-79 — report to user for a decision, do not auto-fix
+- **Discard**: confidence < 60 — ignore silently
+
+If the auto-fix bucket is empty:
+
+- If the ask-user bucket is also empty, report "No actionable findings" and stop.
+- Otherwise, report the ask-user findings and stop — wait for the user to tell you which to address.
+
+## Step 4: Apply Fixes
+
+For each auto-fix finding, apply the suggested change using Edit or Write. After each fix:
+
+1. Re-read the file to confirm the edit landed correctly
+2. Keep a running list of `(path, description)` pairs for the commit message
+
+Do NOT batch edits — apply one finding at a time so failures are isolated.
+
+## Step 5: Build Verification
+
+Before committing, run the project's build. This step is **mandatory** — do not skip it even if the changes seem trivial.
+
+Find the build command:
+
+1. Read `CLAUDE.md` in the project root, if present, for a documented build command
+2. If not documented, check for common build systems in this order:
+   - `Package.swift` → `swift build`
+   - `*.xcodeproj` → `xcodebuild -scheme $(ls -1 *.xcodeproj | head -1 | sed 's/.xcodeproj$//') -quiet build`
+   - `package.json` with a `build` script → `npm run build`
+   - `Cargo.toml` → `cargo build`
+   - `Makefile` with a `build` target → `make build`
+3. If none match, ask the user for the build command
+
+Run the build. If it fails:
+
+1. Show the error output to the user
+2. Do NOT attempt to fix the build failure automatically — the fix may require reverting a finding
+3. Stop and wait for user guidance
+
+If the build passes, continue.
+
+## Step 6: Confirmation Checkpoint
+
+Before committing and pushing, show the user:
+
+- The PR number and title
+- The list of fixes applied (path + description for each)
+- The build verification result (passed)
+- The pending commit message draft
+
+Ask the user to confirm before proceeding. Do NOT commit or push without explicit confirmation. If the user declines, leave the working tree as-is (fixes applied but uncommitted) so they can adjust.
+
+## Step 7: Commit and Push
+
+On confirmation:
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+review: address findings from /review-and-fix
+
+<bulleted list of fixes, one per line>
+EOF
+)"
+git push
+```
+
+Do not use `--no-verify`. If a pre-commit hook fails, stop and report — do not bypass.
+
+## Step 8: Report Summary
+
+Report to the user:
+
+- **PR**: `#<number> <title>`
+- **Fixes applied**: count and bullet list
+- **Ask-user findings**: count and bullet list (if any were surfaced in Step 3)
+- **Build**: passed
+- **Commit**: SHA and push status
+- **Next step**: suggest running `/monitor-prs` or viewing the PR to confirm CI is green

--- a/plugins/workflow/hooks/hooks.json
+++ b/plugins/workflow/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/session-context.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/workflow/scripts/session-context.sh
+++ b/plugins/workflow/scripts/session-context.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Emit git worktree context at session start so Claude (and any subagents
+# it dispatches) always know which working tree they are operating in.
+#
+# Prevents the "subagent edited the main repo instead of the worktree"
+# failure mode by making the current worktree path explicit up front.
+
+set -u
+
+CWD=$(pwd)
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "Session context: git not available, skipping worktree detection."
+    echo "Working directory: $CWD"
+    exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Session context: not inside a git repository."
+    echo "Working directory: $CWD"
+    exit 0
+fi
+
+TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null || echo "$CWD")
+BRANCH=$(git branch --show-current 2>/dev/null || echo "(detached)")
+COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || echo "")
+
+if [ -n "$COMMON_DIR" ] && [ -n "$GIT_DIR" ]; then
+    ABS_COMMON=$(cd "$COMMON_DIR" 2>/dev/null && pwd || echo "$COMMON_DIR")
+    ABS_GIT=$(cd "$GIT_DIR" 2>/dev/null && pwd || echo "$GIT_DIR")
+    if [ "$ABS_COMMON" != "$ABS_GIT" ]; then
+        IS_WORKTREE=1
+    else
+        IS_WORKTREE=0
+    fi
+else
+    IS_WORKTREE=0
+fi
+
+echo "Session context:"
+echo "- Working directory: $CWD"
+echo "- Git toplevel:      $TOPLEVEL"
+echo "- Current branch:    $BRANCH"
+
+if [ "$IS_WORKTREE" = "1" ]; then
+    MAIN_REPO=$(dirname "$ABS_COMMON" 2>/dev/null || echo "unknown")
+    echo "- Worktree:          YES (linked from $MAIN_REPO)"
+    echo ""
+    echo "IMPORTANT: You are in a git worktree. All edits and builds must"
+    echo "stay within $TOPLEVEL. Do NOT 'cd' to the main repo at $MAIN_REPO."
+    echo "When dispatching subagents, pass the worktree path explicitly."
+else
+    echo "- Worktree:          no (main checkout)"
+fi


### PR DESCRIPTION
## Summary

- **`/review-and-fix [pr-number]`** — new command that runs a review-and-fix cycle on an existing PR. Dispatches a code-review subagent, filters findings by confidence (>=80 auto-fix, 60-79 surfaced for user decision, <60 discarded), applies fixes one at a time, runs mandatory build verification (auto-detects Swift Package / Xcode / npm / Cargo / Make), confirms before commit, then commits and pushes. Refuses to switch branches automatically. Never uses `--no-verify`.
- **SessionStart hook** (`scripts/session-context.sh`) — emits `cwd`, git toplevel, current branch, and explicit worktree detection at session start. When inside a linked worktree, prints the worktree path and main repo path side-by-side with a reminder that subagents must inherit the worktree path. Targets the "subagent accidentally edited the main repo" failure mode.
- **Plugin version bumped** to `2.10.0` and the repo `CLAUDE.md` updated to document both new components under the workflow plugin entry, matching the convention used by `tmux-tools`.

## Test plan

- [ ] After installing v2.10.0, restart Claude Code and confirm the SessionStart hook fires (look for "Session context:" output in the transcript)
- [ ] Verify worktree detection: launch Claude inside a linked git worktree and confirm the hook prints "Worktree: YES" with the linked-from path
- [ ] Verify non-worktree case: launch in a normal checkout and confirm "Worktree: no (main checkout)"
- [ ] Verify graceful degradation: launch outside any git repo and confirm "not inside a git repository" with no errors
- [ ] Run `/review-and-fix` against an existing open PR and confirm it: (a) refuses to switch branches if you're on the wrong one, (b) dispatches the review subagent, (c) surfaces findings by confidence bucket, (d) runs the build before committing, (e) asks for confirmation before pushing
- [ ] Run `/review-and-fix` with no PR open on the current branch and confirm it stops with a clear message instead of trying to open one