### PR TITLE
feat: add flow diagram viewer plugin and spotlight refresh mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,6 +49,10 @@
     {
       "name": "token-tracker",
       "source": "./plugins/token-tracker"
+    },
+    {
+      "name": "flow",
+      "source": "./plugins/flow"
     }
   ]
 }

--- a/plugins/flow/.claude-plugin/plugin.json
+++ b/plugins/flow/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "flow",
+  "description": "Interactive flow/diagram viewer using React Flow. Renders a JSON graph in the browser with live two-way sync so the LLM and user can collaborate on diagrams.",
+  "version": "0.2.0",
+  "author": {
+    "name": "Scott",
+    "email": "scott.jungling@gmail.com"
+  },
+  "license": "MIT",
+  "keywords": ["diagram", "flowchart", "visualization", "react-flow", "graph"]
+}

--- a/plugins/flow/commands/flow.md
+++ b/plugins/flow/commands/flow.md
@@ -1,0 +1,79 @@
+---
+description: Start (or stop) an interactive flow/diagram viewer backed by a local JSON file
+argument-hint: "[name|stop] [--port N]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+---
+
+# /flow
+
+Spin up a local React Flow viewer so the user can see — and interactively edit — a diagram described as JSON in `.claude/diagrams/<name>.json`. The LLM and the browser share the file: you write JSON, the user drags / edits nodes in the browser, and the file updates so you can read their changes on the next turn.
+
+## Arguments
+
+`$ARGUMENTS` — one of:
+- _(empty)_ or `<name>` → start the server for diagram `<name>` (default: `diagram`).
+- `stop` → shut down the running server.
+- Append `--port N` to override the default port `4173`.
+
+## Behavior
+
+### Starting
+
+1. Parse `$ARGUMENTS` → diagram `<name>` (default `diagram`), optional `--port <N>` (default `4173`).
+2. Project root: `git rev-parse --show-toplevel` (fall back to cwd if not a git repo).
+3. If `.claude/diagrams/.server.pid` exists and that PID is alive (`kill -0 <pid>`), tell the user the server is already running and print the URL. Do not start a second one. If the PID is stale, delete the file.
+4. Use the **Write** tool to ensure `.claude/diagrams/<name>.json` exists. If missing, seed it with `{"nodes": [], "edges": []}`. If the user described a diagram in this conversation, write an initial graph (nodes + edges) to that file **before** launching so the viewer opens populated.
+5. Launch the server in the background via Bash:
+   ```bash
+   FLOW_PORT=<port> FLOW_PROJECT_ROOT=<project-root> FLOW_DIAGRAM=<name> \
+     nohup node "${CLAUDE_PLUGIN_ROOT}/server/server.mjs" \
+     > .claude/diagrams/.server.log 2>&1 &
+   disown
+   ```
+6. Print the URL (`http://localhost:<port>`) and the diagram file path. Tell the user: "Say _done_ (or run `/flow:flow stop`) when you're finished and I'll tear it down."
+
+### Stopping
+
+1. Read PID from `.claude/diagrams/.server.pid`.
+2. Send SIGTERM — the server traps it and exits cleanly:
+   ```bash
+   kill "$(cat .claude/diagrams/.server.pid)" 2>/dev/null || true
+   rm -f .claude/diagrams/.server.pid
+   ```
+3. Confirm shutdown to the user.
+
+## Graph JSON shape
+
+Native React Flow. Nodes default to a custom `editable` type if `type` is omitted:
+
+```json
+{
+  "nodes": [
+    { "id": "a", "data": { "label": "Start" }, "position": { "x": 0, "y": 0 } },
+    { "id": "b", "data": { "label": "Decide" } }
+  ],
+  "edges": [
+    { "id": "a-b", "source": "a", "target": "b", "label": "go" }
+  ]
+}
+```
+
+- `position` is optional — the viewer auto-lays out missing nodes with dagre.
+- Edge `id` must be unique. Convention: `<source>-<target>`.
+- To reflect user edits in subsequent turns, **re-read** the JSON file before writing new versions.
+
+## Viewer UX
+
+- Dagre DAG layout with direction picker (LR / TB / RL / BT) and a `relayout` button.
+- Double-click a node to rename; Backspace / Delete removes selected nodes or edges.
+- Connection handles are visible on both sides of each node; drag from one to another to connect.
+- Changes are debounced and PUT to the server within ~300ms.
+- Server watches the JSON file with `fs.watch` and pushes SSE updates so LLM-initiated writes are reflected live.
+
+## Notes
+
+- Dependencies (React, React Flow, dagre) load from `esm.sh` at runtime — no install step.
+- The command uses `Bash` (node, kill, mkdir, git) and `Write` (JSON seeding). No `curl` required.

--- a/plugins/flow/server/index.html
+++ b/plugins/flow/server/index.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>flow</title>
+    <style>
+      html, body, #root { height: 100%; margin: 0; font-family: ui-sans-serif, system-ui; }
+      #toolbar {
+        position: fixed; top: 8px; left: 8px; z-index: 10;
+        background: #111; color: #eee; padding: 6px 10px; border-radius: 6px;
+        display: flex; gap: 8px; align-items: center; font-size: 12px;
+      }
+      #toolbar button, #toolbar select {
+        background: #333; color: #eee; border: 0; padding: 4px 8px; border-radius: 4px; cursor: pointer; font: inherit;
+      }
+      #toolbar button:hover { background: #444; }
+      #status { opacity: 0.7; }
+      .editable-node {
+        background: #fff; border: 1px solid #999; border-radius: 6px;
+        padding: 8px 12px; font-size: 12px; min-width: 120px; text-align: center;
+        box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+      }
+      .editable-node.selected { border-color: #2563eb; box-shadow: 0 0 0 2px rgba(37,99,235,0.2); }
+      .editable-node input {
+        width: 100%; border: 0; outline: 0; font: inherit; text-align: center; background: transparent;
+      }
+      .react-flow__handle { width: 10px; height: 10px; background: #2563eb; border: 2px solid #fff; }
+      #hint {
+        position: fixed; bottom: 8px; left: 8px; z-index: 10;
+        background: rgba(17,17,17,0.85); color: #ccc; padding: 6px 10px;
+        border-radius: 6px; font-size: 11px; line-height: 1.4;
+      }
+    </style>
+    <link rel="stylesheet" href="https://esm.sh/reactflow@11.11.4/dist/style.css" />
+  </head>
+  <body>
+    <div id="toolbar">
+      <strong>flow</strong>
+      <span id="diagram-name"></span>
+      <button id="add-node">+ node</button>
+      <label>layout
+        <select id="direction">
+          <option value="LR" selected>left → right</option>
+          <option value="TB">top → bottom</option>
+          <option value="RL">right → left</option>
+          <option value="BT">bottom → top</option>
+        </select>
+      </label>
+      <button id="relayout">relayout</button>
+      <span id="status">idle</span>
+    </div>
+    <div id="hint">double-click a node to rename · backspace/delete removes selection · drag from the blue handle to connect</div>
+    <div id="root"></div>
+
+    <script type="module">
+      import React, { useCallback, useEffect, useState, useRef, memo } from 'https://esm.sh/react@18.3.1';
+      import { createRoot } from 'https://esm.sh/react-dom@18.3.1/client';
+      import ReactFlow, {
+        Background, Controls, MiniMap, addEdge,
+        applyNodeChanges, applyEdgeChanges, Handle, Position, useReactFlow, ReactFlowProvider,
+      } from 'https://esm.sh/reactflow@11.11.4?deps=react@18.3.1,react-dom@18.3.1';
+      import dagre from 'https://esm.sh/@dagrejs/dagre@1.1.4';
+
+      const h = React.createElement;
+      const NODE_W = 160, NODE_H = 48;
+
+      function layout(nodes, edges, dir = 'LR') {
+        const g = new dagre.graphlib.Graph();
+        g.setDefaultEdgeLabel(() => ({}));
+        g.setGraph({ rankdir: dir, nodesep: 40, ranksep: 80 });
+        nodes.forEach(n => g.setNode(n.id, { width: n.width || NODE_W, height: n.height || NODE_H }));
+        edges.forEach(e => g.setEdge(e.source, e.target));
+        dagre.layout(g);
+        const vertical = dir === 'TB' || dir === 'BT';
+        return nodes.map(n => {
+          const p = g.node(n.id);
+          const w = n.width || NODE_W, hh = n.height || NODE_H;
+          return {
+            ...n,
+            position: { x: p.x - w / 2, y: p.y - hh / 2 },
+            sourcePosition: vertical ? Position.Bottom : Position.Right,
+            targetPosition: vertical ? Position.Top : Position.Left,
+          };
+        });
+      }
+
+      function ensurePositions(nodes, edges, dir) {
+        const missing = nodes.some(n => !n.position || typeof n.position.x !== 'number');
+        return missing ? layout(nodes, edges, dir) : nodes;
+      }
+
+      // Editable node: double-click label to rename, visible handles both sides.
+      const EditableNode = memo(({ id, data, selected, sourcePosition, targetPosition }) => {
+        const [editing, setEditing] = useState(false);
+        const [text, setText] = useState(data.label ?? id);
+        useEffect(() => { setText(data.label ?? id); }, [data.label, id]);
+        const commit = () => {
+          setEditing(false);
+          if (text !== data.label) window.__flowRenameNode?.(id, text);
+        };
+        return h('div', {
+          className: 'editable-node' + (selected ? ' selected' : ''),
+          onDoubleClick: () => setEditing(true),
+        },
+          h(Handle, { type: 'target', position: targetPosition || Position.Left }),
+          editing
+            ? h('input', {
+                autoFocus: true,
+                value: text,
+                onChange: e => setText(e.target.value),
+                onBlur: commit,
+                onKeyDown: e => {
+                  if (e.key === 'Enter') commit();
+                  if (e.key === 'Escape') { setText(data.label ?? id); setEditing(false); }
+                },
+              })
+            : h('div', null, data.label ?? id),
+          h(Handle, { type: 'source', position: sourcePosition || Position.Right }),
+        );
+      });
+      const nodeTypes = { editable: EditableNode };
+
+      function normalizeType(nodes) {
+        return nodes.map(n => ({ ...n, type: n.type || 'editable' }));
+      }
+
+      function App() {
+        const [nodes, setNodes] = useState([]);
+        const [edges, setEdges] = useState([]);
+        const [direction, setDirection] = useState('LR');
+        const [status, setStatus] = useState('loading');
+        const suppressSave = useRef(false);
+        const saveTimer = useRef(null);
+        const directionRef = useRef(direction);
+        directionRef.current = direction;
+
+        const load = useCallback(async () => {
+          const r = await fetch('/graph');
+          const g = await r.json();
+          suppressSave.current = true;
+          const ns = normalizeType(ensurePositions(g.nodes || [], g.edges || [], directionRef.current));
+          setNodes(ns);
+          setEdges(g.edges || []);
+          setStatus('loaded');
+          setTimeout(() => { suppressSave.current = false; }, 100);
+        }, []);
+
+        useEffect(() => { load(); }, [load]);
+
+        useEffect(() => {
+          fetch('/meta').then(r => r.json()).then(m => {
+            document.getElementById('diagram-name').textContent = m.diagram;
+            document.title = `flow — ${m.diagram}`;
+          });
+          const es = new EventSource('/events');
+          es.addEventListener('graph-updated', () => {
+            setStatus('external change');
+            load();
+          });
+          return () => es.close();
+        }, [load]);
+
+        useEffect(() => {
+          document.getElementById('status').textContent = status;
+        }, [status]);
+
+        const save = useCallback((ns, es) => {
+          if (suppressSave.current) return;
+          clearTimeout(saveTimer.current);
+          saveTimer.current = setTimeout(async () => {
+            setStatus('saving');
+            await fetch('/graph', {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ nodes: ns, edges: es }, null, 2),
+            });
+            setStatus('saved');
+          }, 300);
+        }, []);
+
+        const onNodesChange = useCallback(changes => {
+          setNodes(ns => {
+            const next = applyNodeChanges(changes, ns);
+            save(next, edges);
+            return next;
+          });
+        }, [edges, save]);
+
+        const onEdgesChange = useCallback(changes => {
+          setEdges(es => {
+            const next = applyEdgeChanges(changes, es);
+            save(nodes, next);
+            return next;
+          });
+        }, [nodes, save]);
+
+        const onConnect = useCallback(conn => {
+          setEdges(es => {
+            const next = addEdge({ ...conn, id: `${conn.source}-${conn.target}` }, es);
+            save(nodes, next);
+            return next;
+          });
+        }, [nodes, save]);
+
+        // Expose rename hook for the custom node (simpler than threading callbacks).
+        useEffect(() => {
+          window.__flowRenameNode = (id, label) => {
+            setNodes(ns => {
+              const next = ns.map(n => n.id === id ? { ...n, data: { ...n.data, label } } : n);
+              save(next, edges);
+              return next;
+            });
+          };
+          return () => { delete window.__flowRenameNode; };
+        }, [edges, save]);
+
+        useEffect(() => {
+          const addBtn = document.getElementById('add-node');
+          const relayoutBtn = document.getElementById('relayout');
+          const dirSel = document.getElementById('direction');
+          const onAdd = () => {
+            const id = `n${Date.now().toString(36)}`;
+            const next = [...nodes, { id, type: 'editable', data: { label: id }, position: { x: 40, y: 40 } }];
+            setNodes(next);
+            save(next, edges);
+          };
+          const onRelayout = () => {
+            const next = normalizeType(layout(nodes, edges, directionRef.current));
+            setNodes(next);
+            save(next, edges);
+          };
+          const onDir = e => setDirection(e.target.value);
+          addBtn.addEventListener('click', onAdd);
+          relayoutBtn.addEventListener('click', onRelayout);
+          dirSel.addEventListener('change', onDir);
+          return () => {
+            addBtn.removeEventListener('click', onAdd);
+            relayoutBtn.removeEventListener('click', onRelayout);
+            dirSel.removeEventListener('change', onDir);
+          };
+        }, [nodes, edges, save]);
+
+        return h(ReactFlow, {
+          nodes, edges, onNodesChange, onEdgesChange, onConnect,
+          nodeTypes, fitView: true,
+          deleteKeyCode: ['Backspace', 'Delete'],
+          snapToGrid: true, snapGrid: [10, 10],
+          defaultEdgeOptions: { animated: false, markerEnd: { type: 'arrowclosed' } },
+        }, h(Background, { gap: 16 }), h(Controls), h(MiniMap, { pannable: true, zoomable: true }));
+      }
+
+      createRoot(document.getElementById('root')).render(h(ReactFlowProvider, null, h(App)));
+    </script>
+  </body>
+</html>

--- a/plugins/flow/server/server.mjs
+++ b/plugins/flow/server/server.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+import { createServer } from 'node:http';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORT = parseInt(process.env.FLOW_PORT || '4173', 10);
+const PROJECT_ROOT = process.env.FLOW_PROJECT_ROOT || process.cwd();
+const DIAGRAM_NAME = process.env.FLOW_DIAGRAM || 'diagram';
+const DIAGRAMS_DIR = join(PROJECT_ROOT, '.claude', 'diagrams');
+const DIAGRAM_PATH = join(DIAGRAMS_DIR, `${DIAGRAM_NAME}.json`);
+const PID_PATH = join(DIAGRAMS_DIR, '.server.pid');
+
+await mkdir(DIAGRAMS_DIR, { recursive: true });
+
+if (!existsSync(DIAGRAM_PATH)) {
+  await writeFile(DIAGRAM_PATH, JSON.stringify({ nodes: [], edges: [] }, null, 2));
+}
+
+const clients = new Set();
+let lastMtime = 0;
+
+async function readGraph() {
+  const raw = await readFile(DIAGRAM_PATH, 'utf8');
+  return raw;
+}
+
+async function writeGraph(body) {
+  const parsed = JSON.parse(body);
+  if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) {
+    throw new Error('Graph must have nodes[] and edges[]');
+  }
+  await writeFile(DIAGRAM_PATH, JSON.stringify(parsed, null, 2));
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function sse(res) {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.write(`: connected\n\n`);
+  clients.add(res);
+  req => res.on?.('close', () => clients.delete(res));
+}
+
+function broadcast(event, data) {
+  const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  for (const c of clients) c.write(payload);
+}
+
+// Poll file mtime so external edits (LLM writes) push to browser.
+import { stat, watch } from 'node:fs/promises';
+(async () => {
+  try {
+    const watcher = watch(DIAGRAM_PATH);
+    for await (const _ of watcher) broadcast('graph-updated', { file: DIAGRAM_PATH });
+  } catch {}
+})();
+
+const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://localhost:${PORT}`);
+
+    if (req.method === 'GET' && url.pathname === '/') {
+      const html = await readFile(join(__dirname, 'index.html'), 'utf8');
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      return res.end(html);
+    }
+
+    if (req.method === 'GET' && url.pathname === '/graph') {
+      const body = await readGraph();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(body);
+    }
+
+    if (req.method === 'PUT' && url.pathname === '/graph') {
+      const body = await readBody(req);
+      await writeGraph(body);
+      res.writeHead(204);
+      return res.end();
+    }
+
+    if (req.method === 'GET' && url.pathname === '/events') {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      });
+      res.write(`: connected\n\n`);
+      clients.add(res);
+      req.on('close', () => clients.delete(res));
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/meta') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ diagram: DIAGRAM_NAME, path: DIAGRAM_PATH }));
+    }
+
+    if (req.method === 'POST' && url.pathname === '/shutdown') {
+      res.writeHead(204);
+      res.end();
+      setTimeout(() => process.exit(0), 50);
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('not found');
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'text/plain' });
+    res.end(String(err?.stack || err));
+  }
+});
+
+server.listen(PORT, '127.0.0.1', async () => {
+  await writeFile(PID_PATH, String(process.pid));
+  console.log(`flow server pid=${process.pid} port=${PORT} diagram=${DIAGRAM_PATH}`);
+});
+
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Code review and worktree workflow commands",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/workflow/commands/spotlight.md
+++ b/plugins/workflow/commands/spotlight.md
@@ -1,6 +1,6 @@
 ---
 description: Spotlight worktree changes into main worktree for testing (like Conductor Spotlight)
-argument-hint: [on|off|status]
+argument-hint: [on|off|refresh|status]
 allowed-tools:
   - Bash(git:*)
 ---
@@ -8,7 +8,7 @@ allowed-tools:
 Spotlight testing: merge worktree changes into the main worktree without committing,
 so you can test in the main worktree's environment (build artifacts, node_modules, databases, etc.).
 
-Parse `$ARGUMENTS` for the mode: `on` (default if empty), `off`, or `status`.
+Parse `$ARGUMENTS` for the mode: `on` (default if empty), `off`, `refresh`, or `status`.
 
 ## Step 1: Detect Environment
 
@@ -57,6 +57,22 @@ If NOT in a linked worktree, abort with:
      - Run `/spotlight off` when done to clean up
    - **Conflicts**: Report conflicting files. User can resolve in main worktree or
      run `/spotlight off` to abort
+
+### Mode: `refresh`
+
+Re-spotlight the current branch's latest state into the main worktree. Useful after making new commits on the feature branch — avoids the `off` + `on` dance.
+
+1. **Clear any existing spotlight in main:**
+   - If main worktree has an active merge (MERGE_HEAD exists): `git -C <main-worktree-path> merge --abort`
+   - Otherwise continue.
+
+2. **Undo a prior checkpoint commit (if any):**
+   - If current worktree HEAD subject is `spotlight: checkpoint`: `git reset --soft HEAD~1`.
+
+3. **Re-run the `on` flow:** checkpoint any uncommitted changes, then
+   `git -C <main-worktree-path> merge --no-commit --no-ff <branch>`.
+
+4. **Report** the refreshed state (branch, main worktree path, whether a new checkpoint was created).
 
 ### Mode: `off`
 


### PR DESCRIPTION
## Summary
- New **flow** plugin: `/flow:flow [name]` spins up a local React Flow viewer backed by a JSON file at `.claude/diagrams/<name>.json` so the LLM and user can collaborate on diagrams across turns. Dagre DAG layout (LR/TB/RL/BT), editable nodes (double-click to rename), SSE live reload, SIGTERM-based shutdown. React/React Flow/dagre load from esm.sh — no install step.
- **workflow** plugin gains a `/workflow:spotlight refresh` mode that aborts the active merge, undoes any prior `spotlight: checkpoint`, and re-runs `on` — avoids the `off` + `on` dance when iterating on a branch during a spotlight session. Bumps to 2.12.0.

## Test plan
- [ ] Install: `/plugin marketplace update sjungling-plugins && /plugin install flow@sjungling-plugins && /reload-plugins`
- [ ] `/flow:flow my-diagram` seeds JSON, launches server on 4173, opens in browser
- [ ] Drag/rename/delete nodes; confirm `.claude/diagrams/my-diagram.json` updates within ~300ms
- [ ] LLM edits JSON file → browser live-reloads via SSE
- [ ] `/flow:flow stop` cleanly terminates (no curl required)
- [ ] `/workflow:spotlight on`, make a commit on branch, then `/workflow:spotlight refresh` picks up the new HEAD without first running `off`