### PR TITLE
fix(technical-writer): correct obsidian CLI commands in vault-manager skill

### DIFF
--- a/plugins/technical-writer/.claude-plugin/plugin.json
+++ b/plugins/technical-writer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "technical-writer",
   "description": "Technical documentation specialist for README files, API docs, user guides, specifications, and release notes with Obsidian vault management",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/technical-writer/skills/obsidian-vault-manager/SKILL.md
+++ b/plugins/technical-writer/skills/obsidian-vault-manager/SKILL.md
@@ -22,7 +22,8 @@ Before performing vault operations:
 
 3. **Find vault path on disk** (needed for direct file writes):
    ```bash
-   grep -o '"path":"[^"]*<vault-name>[^"]*"' ~/Library/Application\ Support/obsidian/obsidian.json
+   # Ask the user where their vault lives, or check Obsidian's config file
+   # (location varies by OS — see the CLI reference for details)
    ```
 
 ## Overview
@@ -56,19 +57,18 @@ Before performing vault operations:
 # List vaults to confirm the name
 obsidian vaults
 
-# Get the disk path for direct writes
-grep -o '"path":"[^"]*<vault-name>[^"]*"' ~/Library/Application\ Support/obsidian/obsidian.json
-# Example output: "path":"/Users/me/Library/Mobile Documents/iCloud~md~obsidian/Documents/my vault"
+# Get the disk path — ask the user, or find it in Obsidian's config file
+# (see the CLI reference for how to locate it on each OS)
 ```
 
 ### Step 2 — Explore Structure
 
 ```bash
 # List folders
-obsidian "vault=my vault" folders
+obsidian "vault=<name>" folders
 
 # Search for existing notes
-obsidian "vault=my vault" search query="devcenter" path=til format=json
+obsidian "vault=<name>" search query="<topic>" path=<folder> format=json
 ```
 
 ### Step 3 — Create Notes with Rich Content
@@ -76,23 +76,20 @@ obsidian "vault=my vault" search query="devcenter" path=til format=json
 The CLI `create` command works for simple single-line content. For notes with frontmatter and multiple paragraphs, **write directly to the vault path**:
 
 ```bash
-# Get vault path
-VAULT_PATH="/Users/me/Library/Mobile Documents/iCloud~md~obsidian/Documents/my vault"
-
 # Write note directly (preserves all content, newlines, frontmatter)
-# Use the Write tool with the full path: $VAULT_PATH/til/2026-04-27 My TIL.md
+# Use the Write tool with the full path: <vault-path>/folder/note.md
 ```
 
 **Look at an existing note first** to match local formatting conventions (tag names, frontmatter fields, `index` backlinks, etc.):
 ```bash
-obsidian "vault=my vault" read "some existing note"
+obsidian "vault=<name>" read "<existing note name>"
 ```
 
 ### Moving/Reorganizing Notes
 
 ```bash
 # ✅ CORRECT: Auto-updates all links
-obsidian "vault=my vault" move path="Random Notes/Design.md" newpath="Projects/Design.md"
+obsidian "vault=<name>" move path="Random Notes/Design.md" newpath="Projects/Design.md"
 
 # ❌ WRONG: Breaks all links to this note
 mv "vault/Random Notes/Design.md" "vault/Projects/Design.md"

--- a/plugins/technical-writer/skills/obsidian-vault-manager/SKILL.md
+++ b/plugins/technical-writer/skills/obsidian-vault-manager/SKILL.md
@@ -20,10 +20,9 @@ Before performing vault operations:
    obsidian vaults
    ```
 
-3. **Find vault path on disk** (needed for direct file writes):
+3. **Get vault path:**
    ```bash
-   # Ask the user where their vault lives, or check Obsidian's config file
-   # (location varies by OS — see the CLI reference for details)
+   obsidian vault "<name>" info=path
    ```
 
 ## Overview
@@ -35,10 +34,12 @@ Before performing vault operations:
 | Task | Command | Notes |
 |------|---------|-------|
 | List vaults | `obsidian vaults` | Always run first |
+| Vault info | `obsidian vault "<name>"` | Name, path, file count |
+| Vault path | `obsidian vault "<name>" info=path` | Path only, good for scripting |
 | List folders | `obsidian "vault=<name>" folders` | Quote vault name if it has spaces |
 | Read note | `obsidian "vault=<name>" read "<note name>"` | Reads by name (fuzzy) |
-| Create note (simple) | `obsidian "vault=<name>" create path="folder/name.md" content="<text>"` | Single-line content only |
-| Create note (rich) | Write directly to vault path on disk | Use for multi-line/frontmatter content |
+| Create note | `obsidian "vault=<name>" create path="folder/name.md" content="$CONTENT"` | Use `printf` to build `$CONTENT` for multi-line |
+| Overwrite note | `obsidian "vault=<name>" create path="..." content="$CONTENT" overwrite` | |
 | Append to note | `obsidian "vault=<name>" append path="<path>" content="<text>"` | |
 | Move note | `obsidian "vault=<name>" move path="old.md" newpath="new.md"` | **Auto-updates all links** |
 | Search content | `obsidian "vault=<name>" search query="<term>" [path=<folder>] [format=json]` | |
@@ -57,8 +58,11 @@ Before performing vault operations:
 # List vaults to confirm the name
 obsidian vaults
 
-# Get the disk path — ask the user, or find it in Obsidian's config file
-# (see the CLI reference for how to locate it on each OS)
+# Get full info (name, path, file count)
+obsidian vault "<name>"
+
+# Get just the path (useful for scripting)
+VAULT_PATH=$(obsidian vault "<name>" info=path)
 ```
 
 ### Step 2 — Explore Structure
@@ -73,11 +77,11 @@ obsidian "vault=<name>" search query="<topic>" path=<folder> format=json
 
 ### Step 3 — Create Notes with Rich Content
 
-The CLI `create` command works for simple single-line content. For notes with frontmatter and multiple paragraphs, **write directly to the vault path**:
+Use `printf` to build the content variable — this correctly handles newlines and multi-line content including frontmatter:
 
 ```bash
-# Write note directly (preserves all content, newlines, frontmatter)
-# Use the Write tool with the full path: <vault-path>/folder/note.md
+CONTENT=$(printf '---\ntags:\n  - til\nindex: "[[Today I learned]]"\n---\n## Heading\n\nContent here.')
+obsidian "vault=<name>" create path="til/2026-04-27 My Note.md" content="$CONTENT"
 ```
 
 **Look at an existing note first** to match local formatting conventions (tag names, frontmatter fields, `index` backlinks, etc.):
@@ -101,16 +105,15 @@ mv "vault/Random Notes/Design.md" "vault/Projects/Design.md"
 |---------|-----------|-----|
 | Using `obsidian-cli` | That's a different npm package — the tool is `obsidian` | Use `obsidian` |
 | Using `--flags` syntax | The CLI uses `key=value` positional args, not `--flags` | Use `key=value` format |
-| `create` with `\n` content | Multi-line content gets stripped to frontmatter only | Write directly to vault path |
+| `create` with `\n` in double-quoted string | Escapes get stripped, content truncated | Use `printf` to build a `$CONTENT` variable |
 | Using `mv` to move notes | Breaks all `[[wiki-links]]` to that note | Use `obsidian move` |
 | Not checking existing note format | Each vault has different tagging/frontmatter conventions | Read an existing note first |
 | Using absolute paths in wiki-links | Breaks when vault moves | Use vault-relative paths |
 
 ## When to Use Standard Tools
 
-- **Rich note creation**: Use `Write` tool with the full disk path (faster, no content truncation)
 - **Bulk content editing**: Use `Edit` after reading with `obsidian read`
-- **Complex search patterns**: Use `Grep` directly on the vault path
+- **Complex search patterns**: Use `Grep` directly on the vault path (use `obsidian vault "<name>" info=path` to get it)
 
 **Always preserve:**
 - Frontmatter (YAML between `---`)

--- a/plugins/technical-writer/skills/obsidian-vault-manager/SKILL.md
+++ b/plugins/technical-writer/skills/obsidian-vault-manager/SKILL.md
@@ -9,136 +9,111 @@ description: This skill should be used when the user asks to "manage Obsidian va
 
 Before performing vault operations:
 
-1. **Verify obsidian-cli is installed:**
+1. **Verify obsidian CLI is installed:**
    ```bash
-   obsidian-cli --version
+   obsidian --version
+   ```
+   The CLI is the native `obsidian` binary that ships with the Obsidian desktop app — not a separate npm package.
+
+2. **List available vaults:**
+   ```bash
+   obsidian vaults
    ```
 
-2. **If obsidian-cli is unavailable:**
-   - Install via: `npm install -g @johnlindquist/obsidian-cli`
-   - Fallback: Standard file operations can be used but will NOT preserve wiki-links
-   - Warning: Without obsidian-cli, moving notes will break all internal `[[wiki-links]]`
-
-3. **Verify vault is accessible:**
+3. **Find vault path on disk** (needed for direct file writes):
    ```bash
-   obsidian-cli print-default
+   grep -o '"path":"[^"]*<vault-name>[^"]*"' ~/Library/Application\ Support/obsidian/obsidian.json
    ```
 
 ## Overview
 
-**Use `obsidian-cli` for all Obsidian vault operations.** Standard file tools (mv, Write, Edit) break internal links and ignore vault structure. The `obsidian-cli` tool automatically preserves `[[wiki-links]]` and maintains vault integrity.
-
-## When to Use
-
-This skill activates when:
-- Working with Obsidian vaults (`.md` files with `[[wiki-links]]`)
-- Moving/renaming notes (links must stay valid)
-- Creating notes with Obsidian-specific syntax (wiki-links, checkboxes, tags)
-- Searching vault content or note names
-- Organizing multiple notes across folders
-
-**Don't use for:**
-- General markdown editing outside Obsidian vaults
-- Static documentation (no internal links)
-- Single-file markdown operations
+**Use `obsidian` for vault operations that touch links or structure.** For creating notes with substantial content (multi-line, frontmatter, etc.), use the `Write` tool directly after locating the vault path — the CLI's `create` command strips multi-line content when `\n` escapes are used.
 
 ## Quick Reference
 
 | Task | Command | Notes |
 |------|---------|-------|
-| Check vault | `obsidian-cli print-default` | Always run first |
-| Read note | `obsidian-cli print "Note Name"` | Reads by name or path |
-| Create note | `obsidian-cli create "Name" --content "text"` | Add `--open` to launch Obsidian |
-| Update note | `obsidian-cli create "Name" --content "text" --append` | Use `--overwrite` to replace |
-| Move note | `obsidian-cli move "old/path" "new/path"` | **Auto-updates all links** |
-| Search content | `obsidian-cli search-content "term"` | Searches note contents |
-| Search names | `obsidian-cli search` | Fuzzy search (interactive) |
-| Daily note | `obsidian-cli daily` | Create/open today's note |
+| List vaults | `obsidian vaults` | Always run first |
+| List folders | `obsidian "vault=<name>" folders` | Quote vault name if it has spaces |
+| Read note | `obsidian "vault=<name>" read "<note name>"` | Reads by name (fuzzy) |
+| Create note (simple) | `obsidian "vault=<name>" create path="folder/name.md" content="<text>"` | Single-line content only |
+| Create note (rich) | Write directly to vault path on disk | Use for multi-line/frontmatter content |
+| Append to note | `obsidian "vault=<name>" append path="<path>" content="<text>"` | |
+| Move note | `obsidian "vault=<name>" move path="old.md" newpath="new.md"` | **Auto-updates all links** |
+| Search content | `obsidian "vault=<name>" search query="<term>" [path=<folder>] [format=json]` | |
+| Daily note | `obsidian "vault=<name>" daily` | Create/open today's note |
 
 **See also:**
-- [Complete obsidian-cli Command Reference](./references/obsidian-cli-reference.md) - All commands with flags and advanced usage
+- [Complete obsidian Command Reference](./references/obsidian-cli-reference.md) - All commands with flags and advanced usage
 - [Obsidian Syntax Reference](./references/obsidian-syntax.md) - Wiki-links, tags, frontmatter, and markdown syntax
 - [Note Templates](./assets/templates/) - Daily note, project, and meeting templates
 
 ## Core Workflows
 
-### Always Check Vault First
+### Step 1 — Find the Vault
 
 ```bash
-# REQUIRED before any operation
-obsidian-cli print-default
+# List vaults to confirm the name
+obsidian vaults
 
-# Get path for direct file operations if needed
-VAULT_PATH=$(obsidian-cli print-default --path-only)
+# Get the disk path for direct writes
+grep -o '"path":"[^"]*<vault-name>[^"]*"' ~/Library/Application\ Support/obsidian/obsidian.json
+# Example output: "path":"/Users/me/Library/Mobile Documents/iCloud~md~obsidian/Documents/my vault"
 ```
 
-**Why:** Paths are vault-relative, not repository-relative. Creating files in wrong location breaks vault structure.
+### Step 2 — Explore Structure
 
-**If obsidian-cli is not installed:** Warn the user that move/rename operations will break wiki-links. Offer to install (`npm install -g @johnlindquist/obsidian-cli`). Read and search operations are safe with standard tools.
+```bash
+# List folders
+obsidian "vault=my vault" folders
+
+# Search for existing notes
+obsidian "vault=my vault" search query="devcenter" path=til format=json
+```
+
+### Step 3 — Create Notes with Rich Content
+
+The CLI `create` command works for simple single-line content. For notes with frontmatter and multiple paragraphs, **write directly to the vault path**:
+
+```bash
+# Get vault path
+VAULT_PATH="/Users/me/Library/Mobile Documents/iCloud~md~obsidian/Documents/my vault"
+
+# Write note directly (preserves all content, newlines, frontmatter)
+# Use the Write tool with the full path: $VAULT_PATH/til/2026-04-27 My TIL.md
+```
+
+**Look at an existing note first** to match local formatting conventions (tag names, frontmatter fields, `index` backlinks, etc.):
+```bash
+obsidian "vault=my vault" read "some existing note"
+```
 
 ### Moving/Reorganizing Notes
 
 ```bash
 # ✅ CORRECT: Auto-updates all links
-obsidian-cli move "Random Notes/Design" "Projects/Design"
+obsidian "vault=my vault" move path="Random Notes/Design.md" newpath="Projects/Design.md"
 
 # ❌ WRONG: Breaks all links to this note
 mv "vault/Random Notes/Design.md" "vault/Projects/Design.md"
-```
-
-**Critical:** `obsidian-cli move` updates every link in the vault automatically. Using `mv` or file operations breaks internal references.
-
-### Creating/Updating Notes
-
-```bash
-# Create new note
-obsidian-cli create "Projects/Mobile App" --content "# Mobile App\n\n## Tasks\n- [ ] Task 1"
-
-# Append to existing (safe if file exists)
-obsidian-cli create "Daily Log" --content "\n## Update\n- New entry" --append
-
-# Replace existing (use cautiously)
-obsidian-cli create "Draft" --content "# Fresh content" --overwrite
-```
-
-**Obsidian syntax in `--content`:**
-- Wiki-links: `[[Note Name]]`
-- Tags: `#project`
-- Checkboxes: `- [ ] Task`
-- Newlines: `\n`
-
-**Templates:** Use provided [note templates](./assets/templates/) as starting points for common note types (daily notes, projects, meetings).
-
-### Searching and Organizing
-
-```bash
-# Find notes mentioning topic
-obsidian-cli search-content "API design"
-
-# Read found note
-obsidian-cli print "Backend/API Design"
-
-# Reorganize (preserves all links)
-obsidian-cli move "Backend/API Design" "Projects/Backend/API Design"
 ```
 
 ## Common Mistakes
 
 | Mistake | Why Wrong | Fix |
 |---------|-----------|-----|
-| Using `mv` to move notes | Breaks all `[[wiki-links]]` to that note | Use `obsidian-cli move` |
-| Using `Write` tool for notes | Creates files outside vault or wrong location | Use `obsidian-cli create --content` |
-| Using `Read` for vault notes | Misses vault context, no search integration | Use `obsidian-cli print` |
-| Not checking vault first | Operations fail or create files in wrong place | Always run `print-default` first |
-| Manual link updating with sed | Error-prone, misses bidirectional links | `obsidian-cli move` handles automatically |
-| Using absolute paths | Breaks when vault moves | Use vault-relative paths |
+| Using `obsidian-cli` | That's a different npm package — the tool is `obsidian` | Use `obsidian` |
+| Using `--flags` syntax | The CLI uses `key=value` positional args, not `--flags` | Use `key=value` format |
+| `create` with `\n` content | Multi-line content gets stripped to frontmatter only | Write directly to vault path |
+| Using `mv` to move notes | Breaks all `[[wiki-links]]` to that note | Use `obsidian move` |
+| Not checking existing note format | Each vault has different tagging/frontmatter conventions | Read an existing note first |
+| Using absolute paths in wiki-links | Breaks when vault moves | Use vault-relative paths |
 
 ## When to Use Standard Tools
 
-**Use `obsidian-cli` first.** Only use standard tools when:
-- Bulk editing note contents (use `Edit` after `obsidian-cli print`)
-- Complex search patterns (use `Grep` with vault path)
-- File pattern matching (use `Glob` on `$VAULT_PATH/**/*.md`)
+- **Rich note creation**: Use `Write` tool with the full disk path (faster, no content truncation)
+- **Bulk content editing**: Use `Edit` after reading with `obsidian read`
+- **Complex search patterns**: Use `Grep` directly on the vault path
 
 **Always preserve:**
 - Frontmatter (YAML between `---`)
@@ -146,25 +121,10 @@ obsidian-cli move "Backend/API Design" "Projects/Backend/API Design"
 - Tag syntax `#tag-name`
 - Markdown structure
 
-## Integration Pattern
-
-```bash
-# 1. Check vault
-obsidian-cli print-default
-
-# 2. Use obsidian-cli for vault operations
-obsidian-cli search-content "search term"
-obsidian-cli print "Found Note"
-
-# 3. Use standard tools ONLY when needed
-# (e.g., complex editing after reading with obsidian-cli)
-```
-
 ## Success Criteria
 
 Vault operations succeed when:
 - All `[[wiki-links]]` remain valid after moves
-- Notes created in correct vault location
-- Markdown and YAML frontmatter preserved intact during all operations
-- Search returns accurate results
+- Notes created in correct vault location with full content intact
+- Formatting matches existing notes in the same folder
 - No broken links or orphaned notes

--- a/plugins/technical-writer/skills/obsidian-vault-manager/references/obsidian-cli-reference.md
+++ b/plugins/technical-writer/skills/obsidian-vault-manager/references/obsidian-cli-reference.md
@@ -1,112 +1,77 @@
-# obsidian-cli Command Reference
+# obsidian CLI Command Reference
 
-Complete reference for `obsidian-cli` commands and advanced usage patterns.
+Complete reference for the `obsidian` CLI. This is the **native Obsidian binary**, not an npm package.
 
 ## Installation
 
+The `obsidian` CLI ships with the Obsidian desktop app. Verify it's on your PATH:
+
 ```bash
-npm install -g @johnlindquist/obsidian-cli
+obsidian --version
 ```
 
-Verify installation:
+## Vault Targeting
+
+All vault commands use `vault=<name>` as a positional key=value argument. Quote it when the vault name has spaces:
+
 ```bash
-obsidian-cli --version
+obsidian "vault=moderne 2" <command>
 ```
 
 ## Core Commands
 
-### print-default
+### vaults
 
-Display current vault information.
+List all vaults Obsidian knows about.
 
 ```bash
-obsidian-cli print-default
+obsidian vaults
 ```
 
-**Flags:**
-- `--path-only` - Output only the vault path (useful for scripting)
+Use this to confirm vault names before targeting them.
 
-**Output:**
-- Vault name
-- Vault path
-- Vault status
+### folders
 
-**Usage:**
+List all folders in a vault.
+
 ```bash
-# Get vault info
-obsidian-cli print-default
-
-# Get path for scripts
-VAULT_PATH=$(obsidian-cli print-default --path-only)
-echo "Vault location: $VAULT_PATH"
+obsidian "vault=<name>" folders
 ```
 
-### print
+### read
 
 Read note contents by name or path.
 
 ```bash
-obsidian-cli print "Note Name"
-obsidian-cli print "folder/Note Name"
+obsidian "vault=<name>" read "<note name or path>"
 ```
 
 **Behavior:**
-- Searches by note name first (without path)
-- Falls back to path-based lookup
+- Fuzzy search by name (no path needed for unique names)
 - Returns full note contents including frontmatter
-- Case-sensitive matching
 
 **Examples:**
 ```bash
-# Read by name
-obsidian-cli print "Project Plan"
-
-# Read by path
-obsidian-cli print "Work/Projects/Project Plan"
-
-# Pipe to other tools
-obsidian-cli print "Note" | grep "TODO"
+obsidian "vault=moderne 2" read "2026-04-23 macOS Limit IP Address Tracking"
+obsidian "vault=moderne 2" read "til/2026-04-23 macOS Limit IP Address Tracking.md"
 ```
 
 ### create
 
-Create new notes or update existing ones.
+Create a new note. **Only reliable for single-line or very short content.** Multi-line content passed via `\n` escapes gets stripped to frontmatter only.
 
 ```bash
-obsidian-cli create "Note Name" --content "content"
+obsidian "vault=<name>" create path="folder/note.md" content="<text>"
 ```
 
-**Required Flags:**
-- `--content "text"` - Note content (supports `\n` for newlines)
+**For notes with frontmatter, multiple paragraphs, or code blocks:** write directly to the vault's disk path using the `Write` tool instead.
 
-**Optional Flags:**
-- `--append` - Add content to end of existing note (safe for existing files)
-- `--overwrite` - Replace entire note (destructive)
-- `--open` - Open note in Obsidian after creation
+### append
 
-**Content Syntax:**
-- Use `\n` for newlines
-- Include Obsidian syntax: `[[wiki-links]]`, `#tags`, `- [ ]` checkboxes
-- Frontmatter can be included in content
+Append content to an existing note.
 
-**Examples:**
 ```bash
-# Create new note
-obsidian-cli create "Meeting Notes" --content "# Meeting\n\nAttendees: [[John]], [[Sarah]]"
-
-# Append to existing
-obsidian-cli create "Daily Log" --content "\n## 3pm Update\n- Completed task" --append
-
-# Replace existing (caution!)
-obsidian-cli create "Draft" --content "# New Draft\n\nStarting over" --overwrite
-
-# Create and open in Obsidian
-obsidian-cli create "Quick Note" --content "# Note" --open
-```
-
-**Frontmatter Example:**
-```bash
-obsidian-cli create "Book Review" --content "---\ntitle: Book Title\nauthor: Author Name\nrating: 5\n---\n\n# Review\n\nExcellent book about [[Topic]]"
+obsidian "vault=<name>" append path="folder/note.md" content="<text>"
 ```
 
 ### move
@@ -114,265 +79,66 @@ obsidian-cli create "Book Review" --content "---\ntitle: Book Title\nauthor: Aut
 Move or rename notes while preserving all wiki-links.
 
 ```bash
-obsidian-cli move "old/path" "new/path"
+obsidian "vault=<name>" move path="old/path.md" newpath="new/path.md"
 ```
 
 **Behavior:**
 - Automatically updates ALL links to moved note throughout entire vault
-- Updates bidirectional links
-- Maintains frontmatter and note content
 - Creates destination folder if needed
 
-**Path Formats:**
-- Vault-relative paths (no leading `/`)
-- With or without `.md` extension
-- Folder paths for organizing
-
-**Examples:**
-```bash
-# Move note to different folder
-obsidian-cli move "Inbox/Idea" "Projects/New Idea"
-
-# Rename note
-obsidian-cli move "Draft Title" "Final Title"
-
-# Reorganize with folders
-obsidian-cli move "Random/Design Doc" "Projects/Mobile/Design Doc"
-
-# Move with .md extension (works the same)
-obsidian-cli move "note.md" "folder/note.md"
-```
-
-**Critical:** This is the ONLY safe way to move notes. Using `mv`, `Write`, or file operations will break all links.
-
-### search-content
-
-Search note contents for text.
-
-```bash
-obsidian-cli search-content "search term"
-```
-
-**Behavior:**
-- Full-text search across all notes
-- Returns matching note paths
-- Case-insensitive by default
-- Searches note content, not just titles
-
-**Examples:**
-```bash
-# Find notes about a topic
-obsidian-cli search-content "API design"
-
-# Find todos
-obsidian-cli search-content "- [ ]"
-
-# Find tagged notes
-obsidian-cli search-content "#important"
-
-# Combine with other commands
-for note in $(obsidian-cli search-content "refactor"); do
-  echo "Found in: $note"
-  obsidian-cli print "$note"
-done
-```
+**This is the only safe way to move notes.** Using `mv` or file operations will break all links.
 
 ### search
 
-Interactive fuzzy search for note names.
+Search note contents.
 
 ```bash
-obsidian-cli search
+obsidian "vault=<name>" search query="<term>" [path=<folder>] [limit=<n>] [format=text|json]
 ```
-
-**Behavior:**
-- Opens interactive picker
-- Fuzzy matching on note names
-- Navigate with arrow keys
-- Press Enter to select
-
-**Usage:**
-- Run command
-- Type to filter notes
-- Select note with Enter
-- Use selected note path in scripts
-
-**Note:** This is interactive and may not work in all automation contexts. Use `search-content` for scripting.
-
-### daily
-
-Create or open daily note.
-
-```bash
-obsidian-cli daily
-```
-
-**Behavior:**
-- Creates note with today's date (YYYY-MM-DD format by default)
-- Opens in Obsidian if it already exists
-- Uses vault's daily note template if configured
 
 **Examples:**
 ```bash
-# Open today's note
-obsidian-cli daily
+# Search entire vault
+obsidian "vault=moderne 2" search query="devcenter"
 
-# Create with custom content
-obsidian-cli daily && obsidian-cli create "$(date +%Y-%m-%d)" --content "\n## Evening Review\n- Accomplishments" --append
+# Search within a folder, return JSON paths
+obsidian "vault=moderne 2" search query="committer" path=til format=json
 ```
 
-## Advanced Usage Patterns
+### daily
 
-### Scripting with obsidian-cli
+Create or open today's daily note.
 
 ```bash
-#!/bin/bash
-
-# Get vault path for reference
-VAULT_PATH=$(obsidian-cli print-default --path-only)
-
-# Search and process notes
-obsidian-cli search-content "TODO" | while read -r note; do
-  echo "Processing: $note"
-  content=$(obsidian-cli print "$note")
-  # Process content...
-done
-
-# Bulk reorganization
-for note in $(obsidian-cli search-content "#archive"); do
-  obsidian-cli move "$note" "Archive/$note"
-done
+obsidian "vault=<name>" daily
 ```
 
-### Combining with Standard Tools
+## Finding the Vault Path on Disk
+
+For direct file writes (the preferred method for rich content), find the vault's disk path:
 
 ```bash
-# Use obsidian-cli for vault operations, then standard tools for processing
-obsidian-cli print "Note" > /tmp/note.md
-# Edit with standard tools
-sed -i 's/old/new/g' /tmp/note.md
-# Write back to vault
-obsidian-cli create "Note" --content "$(cat /tmp/note.md)" --overwrite
+grep -o '"path":"[^"]*<vault-name>[^"]*"' ~/Library/Application\ Support/obsidian/obsidian.json
 ```
 
-### Template-Based Note Creation
-
-```bash
-# Read template
-TEMPLATE=$(cat templates/project-template.md)
-
-# Create note with template
-obsidian-cli create "New Project" --content "$TEMPLATE"
-
-# Create with substitutions
-TEMPLATE=$(cat templates/meeting-template.md | sed "s/DATE/$(date +%Y-%m-%d)/g")
-obsidian-cli create "Meeting - Team Sync" --content "$TEMPLATE"
+Common location for iCloud-synced vaults:
 ```
-
-### Batch Operations
-
-```bash
-# Rename multiple notes with pattern
-for note in Project-*; do
-  new_name=$(echo "$note" | sed 's/Project-/Archived-Project-/')
-  obsidian-cli move "$note" "Archive/$new_name"
-done
-
-# Add tag to multiple notes
-obsidian-cli search-content "machine learning" | while read -r note; do
-  content=$(obsidian-cli print "$note")
-  obsidian-cli create "$note" --content "$content\n\n#machine-learning" --append
-done
-```
-
-### Working with Frontmatter
-
-```bash
-# Create note with complex frontmatter
-obsidian-cli create "Article" --content "---
-title: Article Title
-date: $(date +%Y-%m-%d)
-tags:
-  - article
-  - published
-author: John Doe
----
-
-# Article Title
-
-Content here with [[Wiki Links]]"
-```
-
-### Link Integrity Verification
-
-```bash
-# After bulk operations, verify links
-# (obsidian-cli handles this automatically, but for validation:)
-VAULT_PATH=$(obsidian-cli print-default --path-only)
-
-# Use standard tools to find broken links
-grep -r "\[\[.*\]\]" "$VAULT_PATH" | while read -r line; do
-  # Check if target exists
-  # obsidian-cli move ensures this isn't needed
-done
+/Users/<user>/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault name>
 ```
 
 ## Troubleshooting
 
-### Command Not Found
+### Command not found
+The `obsidian` binary is not on PATH. Open Obsidian.app at least once — the binary is bundled with the app.
 
+### Content gets stripped on create
+Multi-line content with `\n` escapes doesn't survive the CLI's argument parsing. Use the `Write` tool to write directly to the vault path on disk instead.
+
+### Note not found by name
+Use the full vault-relative path, or run `search` first to find the exact path:
 ```bash
-# Install globally
-npm install -g @johnlindquist/obsidian-cli
-
-# Or use npx
-npx @johnlindquist/obsidian-cli print-default
+obsidian "vault=<name>" search query="unique phrase" format=json
 ```
-
-### No Default Vault
-
-Error: "No default vault set"
-
-**Solution:**
-- Open Obsidian application
-- Vault must be opened at least once
-- obsidian-cli reads from Obsidian's configuration
-
-### Path Issues
-
-**Problem:** Note not found by name
-
-**Solution:**
-```bash
-# Use full path
-obsidian-cli print "folder/subfolder/Note Name"
-
-# Or search first
-obsidian-cli search-content "unique phrase in note"
-```
-
-### Newlines Not Working
-
-**Problem:** `\n` appears literally in notes
-
-**Solution:**
-```bash
-# Use echo with -e flag
-obsidian-cli create "Note" --content "$(echo -e "Line 1\nLine 2")"
-
-# Or use $'...' syntax
-obsidian-cli create "Note" --content $'Line 1\nLine 2'
-```
-
-## Best Practices
-
-1. **Always check vault first:** Run `print-default` before operations
-2. **Use obsidian-cli move exclusively:** Never use `mv` for notes
-3. **Preserve Obsidian syntax:** Maintain `[[links]]`, `#tags`, frontmatter
-4. **Test on copies:** For bulk operations, test on duplicate notes first
-5. **Use --append safely:** Append is safe for existing files, overwrite is destructive
-6. **Script defensively:** Check command success before proceeding
-7. **Backup regularly:** obsidian-cli is safe, but backups prevent mistakes
 
 ## See Also
 

--- a/plugins/technical-writer/skills/obsidian-vault-manager/references/obsidian-cli-reference.md
+++ b/plugins/technical-writer/skills/obsidian-vault-manager/references/obsidian-cli-reference.md
@@ -20,6 +20,28 @@ obsidian "vault=my vault" <command>
 
 ## Core Commands
 
+### vault
+
+Get info about a specific vault by name.
+
+```bash
+obsidian vault "<name>"
+```
+
+**Output:** name, path, file count, folder count, size.
+
+**Flags:**
+- `info=path` — return only the disk path (useful for scripting)
+
+**Examples:**
+```bash
+# Full vault info
+obsidian vault "my vault"
+
+# Get path for scripting
+VAULT_PATH=$(obsidian vault "my vault" info=path)
+```
+
 ### vaults
 
 List all vaults Obsidian knows about.
@@ -58,13 +80,22 @@ obsidian "vault=my vault" read "til/2024-03-21 Some Note Title.md"
 
 ### create
 
-Create a new note. **Only reliable for single-line or very short content.** Multi-line content passed via `\n` escapes gets stripped to frontmatter only.
+Create a new note.
 
 ```bash
-obsidian "vault=<name>" create path="folder/note.md" content="<text>"
+obsidian "vault=<name>" create path="folder/note.md" content="$CONTENT"
 ```
 
-**For notes with frontmatter, multiple paragraphs, or code blocks:** write directly to the vault's disk path using the `Write` tool instead.
+**Multi-line content:** Pass content via a `printf`-built variable — `\n` escapes inside double-quoted strings get stripped, but `printf` handles them correctly:
+
+```bash
+CONTENT=$(printf '---\ntags:\n  - til\nindex: "[[Today I learned]]"\n---\n## Heading\n\nFull content here, multiple paragraphs, frontmatter all preserved.')
+obsidian "vault=<name>" create path="til/2026-04-27 My Note.md" content="$CONTENT"
+```
+
+**Flags:**
+- `overwrite` — replace file if it already exists
+- `template=<name>` — apply a vault template
 
 ### append
 
@@ -115,15 +146,15 @@ obsidian "vault=<name>" daily
 
 ## Finding the Vault Path on Disk
 
-For direct file writes (the preferred method for rich content), you need the vault's absolute path. The easiest approach is to **ask the user** — they'll know where their vault lives.
+Use the CLI directly:
 
-If the user doesn't know, Obsidian stores vault paths in its config file:
+```bash
+# Full info including path
+obsidian vault "<name>"
 
-- **macOS:** `~/Library/Application Support/obsidian/obsidian.json`
-- **Windows:** `%APPDATA%\obsidian\obsidian.json`
-- **Linux:** `~/.config/obsidian/obsidian.json`
-
-The file contains a `vaults` object; each entry has a `path` field with the absolute disk path.
+# Path only (for scripting)
+VAULT_PATH=$(obsidian vault "<name>" info=path)
+```
 
 ## Troubleshooting
 

--- a/plugins/technical-writer/skills/obsidian-vault-manager/references/obsidian-cli-reference.md
+++ b/plugins/technical-writer/skills/obsidian-vault-manager/references/obsidian-cli-reference.md
@@ -15,7 +15,7 @@ obsidian --version
 All vault commands use `vault=<name>` as a positional key=value argument. Quote it when the vault name has spaces:
 
 ```bash
-obsidian "vault=moderne 2" <command>
+obsidian "vault=my vault" <command>
 ```
 
 ## Core Commands
@@ -52,8 +52,8 @@ obsidian "vault=<name>" read "<note name or path>"
 
 **Examples:**
 ```bash
-obsidian "vault=moderne 2" read "2026-04-23 macOS Limit IP Address Tracking"
-obsidian "vault=moderne 2" read "til/2026-04-23 macOS Limit IP Address Tracking.md"
+obsidian "vault=my vault" read "2024-03-21 Some Note Title"
+obsidian "vault=my vault" read "til/2024-03-21 Some Note Title.md"
 ```
 
 ### create
@@ -99,10 +99,10 @@ obsidian "vault=<name>" search query="<term>" [path=<folder>] [limit=<n>] [forma
 **Examples:**
 ```bash
 # Search entire vault
-obsidian "vault=moderne 2" search query="devcenter"
+obsidian "vault=my vault" search query="API design"
 
 # Search within a folder, return JSON paths
-obsidian "vault=moderne 2" search query="committer" path=til format=json
+obsidian "vault=my vault" search query="setup" path=til format=json
 ```
 
 ### daily
@@ -115,16 +115,15 @@ obsidian "vault=<name>" daily
 
 ## Finding the Vault Path on Disk
 
-For direct file writes (the preferred method for rich content), find the vault's disk path:
+For direct file writes (the preferred method for rich content), you need the vault's absolute path. The easiest approach is to **ask the user** — they'll know where their vault lives.
 
-```bash
-grep -o '"path":"[^"]*<vault-name>[^"]*"' ~/Library/Application\ Support/obsidian/obsidian.json
-```
+If the user doesn't know, Obsidian stores vault paths in its config file:
 
-Common location for iCloud-synced vaults:
-```
-/Users/<user>/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault name>
-```
+- **macOS:** `~/Library/Application Support/obsidian/obsidian.json`
+- **Windows:** `%APPDATA%\obsidian\obsidian.json`
+- **Linux:** `~/.config/obsidian/obsidian.json`
+
+The file contains a `vaults` object; each entry has a `path` field with the absolute disk path.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- The skill documented `obsidian-cli` (a third-party npm package) but the actual CLI is the native `obsidian` binary bundled with the Obsidian desktop app
- Commands use `key=value` positional args, not `--flags` — e.g. `path=`, `content=`, `query=`
- Several commands were renamed or don't exist: `print` → `read`, `print-default` → `vaults`, `search-content` → `search query=`
- Documented the `create` content truncation bug (multi-line `\n` content gets stripped) with the workaround of writing directly to the vault path on disk
- Added vault path discovery via `~/Library/Application Support/obsidian/obsidian.json`
- Bumps plugin to 2.11.0

## Test plan

- [ ] `obsidian --version` works
- [ ] `obsidian vaults` lists vaults
- [ ] `obsidian "vault=<name>" read "<note>"` returns content
- [ ] `obsidian "vault=<name>" search query="<term>" format=json` returns paths
- [ ] Creating a TIL with rich content via Write tool to vault disk path produces correct output