### PR TITLE
refactor(workflow): extract teleport-tmux into a packaged script + fix sandbox masking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Each plugin can contain:
 - Command: `/post-pr-comments` - Post inline code review comments from conversation onto the current branch's PR. Writes a comments JSON file, then uses `gh api` to post a pull request review with targeted line comments.
 - Command: `/monitor-prs` - Monitor open PRs on a recurring basis: review changes, post validated comments, resolve merge conflicts in worktrees, and surface new reviewer feedback. Designed for use with `/loop` (e.g., `/loop 5m /monitor-prs`).
 - Command: `/review-and-fix [pr-number]` - Run a review-and-fix cycle on an existing PR: dispatches a code-review subagent, applies high-confidence fixes (>=80), runs build verification, asks for confirmation, then commits and pushes. Mandatory build gate before commit.
+- Command: `/teleport-tmux [session-name]` - Teleport the current Claude session into a new tmux window so you can close the terminal you accidentally started Claude outside of tmux in. macOS can't move a live process's terminal, so it arms a new tmux window to `claude --resume <session-id>` the moment the old process exits (detected via the ancestor PID + `kill -0`), avoiding concurrent transcript writes. Falls back to a pre-typed manual launch if the old PID can't be detected.
 - Hook: SessionStart - Emits worktree context (cwd, git toplevel, branch, worktree detection) so subagents stay in the correct working tree and don't accidentally edit the main repo.
 
 **data-tools** (`plugins/data-tools/`):

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Code review and worktree workflow commands",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "description": "Code review and worktree workflow commands",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/workflow/commands/teleport-tmux.md
+++ b/plugins/workflow/commands/teleport-tmux.md
@@ -15,82 +15,38 @@ so this does NOT move the running process. Instead it arms a new tmux window to
 the moment the old process exits. The conversation transcript is persisted per
 turn, so everything committed transfers; only truly in-flight work is lost.
 
+All the real work lives in `${CLAUDE_PLUGIN_ROOT}/scripts/teleport-tmux.sh`.
+This command just runs it in two phases and relays the result.
+
+> **IMPORTANT — run every bash block in this command with the sandbox
+> DISABLED** (`dangerouslyDisableSandbox: true`). tmux talks to its server over
+> a Unix socket (e.g. `/private/tmp/tmux-501/default`) that lives outside the
+> default sandbox's writable allowlist. Under the sandbox, `tmux list-sessions`,
+> `new-window`, and `send-keys` all fail with `error connecting to … (Operation
+> not permitted)`. The script surfaces this as `ERROR_LISTING_SESSIONS` instead
+> of silently hiding sessions — but it still cannot create the window unless the
+> sandbox is off. The `command -v tmux` check passes either way (the binary
+> exists), so the failure is easy to miss. Disable the sandbox up front.
+
 Follow this workflow exactly.
 
-## Step 1: Gather state and write the resume script
+## Step 1: Discover state
 
-Run this single block and read its output. It detects the old `claude` process
-and writes a self-contained resume script to a temp file — building the script
-in a real shell (with proper `printf %q` quoting) avoids any fragile text
-substitution or `tmux send-keys` quoting problems later.
+Run this (sandbox disabled) and read its output:
 
 ```bash
-set -euo pipefail
-
-# tmux must be installed
-if ! command -v tmux >/dev/null 2>&1; then
-  echo "ERROR: tmux is not installed. Install it with: brew install tmux"
-  exit 1
-fi
-
-# CLAUDE_CODE_SESSION_ID is an internal Claude Code env var (not shown in
-# `claude --help`); it holds the current session ID we resume. Fail loudly if
-# it ever stops being exported.
-SID="${CLAUDE_CODE_SESSION_ID:-}"
-if [ -z "$SID" ]; then
-  echo "ERROR: CLAUDE_CODE_SESSION_ID is not set; cannot determine which session to resume."
-  exit 1
-fi
-
-CWD="$PWD"
-CLAUDE_BIN="$(command -v claude || echo claude)"
-
-# Walk up the process tree to find the ancestor 'claude' process. Match the
-# basename EXACTLY so we don't match unrelated processes like 'claude-helper'.
-# kill -0 (used inside the resume script) only needs signal permission, so the
-# *wait* is reliable even where ps is restricted; this detection is best-effort.
-OLD_PID=""
-pid="$PPID"
-guard=0
-while [ -n "$pid" ] && [ "$pid" -gt 1 ] && [ "$guard" -lt 25 ]; do
-  comm="$(ps -o comm= -p "$pid" 2>/dev/null || true)"
-  case "${comm##*/}" in
-    claude) OLD_PID="$pid"; break ;;
-  esac
-  pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
-  guard=$((guard + 1))
-done
-
-# Write the resume script the new tmux window will run. It is always invoked as
-# `bash <script>`, so no shebang is needed.
-SCRIPT="${CLAUDE_TMPDIR:-${TMPDIR:-/tmp}}/teleport-resume-${SID}.sh"
-{
-  if [ -n "$OLD_PID" ]; then
-    printf 'echo "Waiting for the original Claude session (PID %s) to exit, then resuming here..."\n' "$OLD_PID"
-    printf 'while kill -0 %s 2>/dev/null; do sleep 0.5; done\n' "$OLD_PID"
-    # Brief pause narrows the PID-reuse / TOCTOU window before we start writing
-    # to the same transcript the old process just released.
-    printf 'sleep 1\n'
-  fi
-  printf 'cd %q || exit 1\n' "$CWD"
-  # No `exec`: keep the pane open if resume fails so the error is visible.
-  printf '%q --resume %q\n' "$CLAUDE_BIN" "$SID"
-  printf 'ec=$?\n'
-  printf '[ "$ec" -ne 0 ] && { echo "claude --resume exited with $ec. Press Enter to close."; read -r _; }\n'
-} > "$SCRIPT"
-chmod +x "$SCRIPT"
-
-echo "SESSION_ID=$SID"
-echo "OLD_PID=${OLD_PID:-<not-detected>}"
-echo "RESUME_SCRIPT=$SCRIPT"
-echo "INSIDE_TMUX=${TMUX:+yes}"
-echo "--- existing tmux sessions ---"
-tmux list-sessions -F '#{session_name}' 2>/dev/null || echo "<none>"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/teleport-tmux.sh" --discover
 ```
 
-Capture from the output: `RESUME_SCRIPT` (path), whether `OLD_PID` was detected
-(`AUTO=yes` if it is a number, `AUTO=no` if `<not-detected>`), whether we're
-`INSIDE_TMUX`, and the list of existing sessions.
+Capture from the output:
+- `RESUME_SCRIPT` — path passed to `--arm` in Step 3.
+- `AUTO` — `yes` if the old `claude` PID was detected, `no` otherwise.
+- `INSIDE_TMUX` — `yes` if we're already inside tmux.
+- The session list under `--- existing tmux sessions ---`.
+
+If you see `ERROR_LISTING_SESSIONS`, the sandbox is still on (or the tmux socket
+is otherwise blocked). Re-run the command with the sandbox disabled before
+continuing — do NOT treat it as "no sessions."
 
 ## Step 2: Resolve the target session
 
@@ -99,46 +55,25 @@ Capture from the output: `RESUME_SCRIPT` (path), whether `OLD_PID` was detected
   - If there are existing sessions, use **AskUserQuestion** to let the user pick
     one, or choose "Create a new session". Offer a sensible default name for a
     new session based on the current directory: `claude-<basename of CWD>`.
-  - If there are no sessions at all, default to creating `claude-<basename of CWD>`
-    (still confirm the name with AskUserQuestion if the user gave no argument).
+  - If `<none>`, default to creating `claude-<basename of CWD>` (still confirm
+    the name with AskUserQuestion if the user gave no argument).
 
 Set `TARGET` to the chosen session name.
 
 ## Step 3: Create the window and arm the resume
 
-Run this block, substituting only these simple, low-risk values: `__TARGET__`
-(the session name), `__SCRIPT__` (the `RESUME_SCRIPT` path from Step 1), and
-`__AUTO__` (`yes` or `no` from Step 1). The window's working directory is set by
-the resume script's own `cd`, so no path needs substituting here.
+Run this (sandbox disabled), substituting `__TARGET__` (chosen session),
+`__SCRIPT__` (the `RESUME_SCRIPT` path from Step 1), and `__AUTO__` (`yes`/`no`
+from Step 1):
 
 ```bash
-set -euo pipefail
-TARGET='__TARGET__'
-SCRIPT='__SCRIPT__'
-AUTO='__AUTO__'
-
-# Create the window and capture its index so send-keys targets THIS window,
-# not whatever window happens to be active in the session.
-if tmux has-session -t "$TARGET" 2>/dev/null; then
-  WIN="$(tmux new-window -t "$TARGET" -n claude -P -F '#{window_index}')"
-else
-  tmux new-session -d -s "$TARGET" -n claude
-  WIN="$(tmux list-windows -t "$TARGET" -F '#{window_index}' | head -n1)"
-fi
-PANE="${TARGET}:${WIN}"
-
-if [ "$AUTO" = yes ]; then
-  # Auto-wait: the script waits for the old process to exit, then resumes. This
-  # prevents two processes appending to the same transcript .jsonl at once.
-  tmux send-keys -t "$PANE" "bash $(printf %q "$SCRIPT")" C-m
-  echo "ARMED_AUTO_WAIT pane=$PANE"
-else
-  # Graceful degradation (PID not detected): pre-type the launch but do NOT run
-  # it, so the user can close the old terminal first, then press Enter.
-  tmux send-keys -t "$PANE" "bash $(printf %q "$SCRIPT")"
-  echo "ARMED_MANUAL pane=$PANE"
-fi
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/teleport-tmux.sh" --arm \
+  --target '__TARGET__' --script '__SCRIPT__' --auto '__AUTO__'
 ```
+
+The script prints `ARMED_AUTO_WAIT` (auto mode) or `ARMED_MANUAL` (PID not
+detected). If it dies with a "tmux socket is blocked" message, the sandbox is
+still on — re-run with it disabled.
 
 ## Step 4: Tell the user what to do
 

--- a/plugins/workflow/commands/teleport-tmux.md
+++ b/plugins/workflow/commands/teleport-tmux.md
@@ -1,0 +1,163 @@
+---
+description: Teleport the current Claude session into a new tmux window so you can close the original terminal
+argument-hint: "[tmux-session-name]"
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+Teleport **this** Claude conversation into a tmux window so the user can close
+the terminal they accidentally started Claude in without losing the session.
+
+macOS cannot move a live process's controlling terminal (no working `reptyr`),
+so this does NOT move the running process. Instead it arms a new tmux window to
+**resume** the current conversation from disk (`claude --resume <session-id>`)
+the moment the old process exits. The conversation transcript is persisted per
+turn, so everything committed transfers; only truly in-flight work is lost.
+
+Follow this workflow exactly.
+
+## Step 1: Gather state and write the resume script
+
+Run this single block and read its output. It detects the old `claude` process
+and writes a self-contained resume script to a temp file — building the script
+in a real shell (with proper `printf %q` quoting) avoids any fragile text
+substitution or `tmux send-keys` quoting problems later.
+
+```bash
+set -euo pipefail
+
+# tmux must be installed
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "ERROR: tmux is not installed. Install it with: brew install tmux"
+  exit 1
+fi
+
+# CLAUDE_CODE_SESSION_ID is an internal Claude Code env var (not shown in
+# `claude --help`); it holds the current session ID we resume. Fail loudly if
+# it ever stops being exported.
+SID="${CLAUDE_CODE_SESSION_ID:-}"
+if [ -z "$SID" ]; then
+  echo "ERROR: CLAUDE_CODE_SESSION_ID is not set; cannot determine which session to resume."
+  exit 1
+fi
+
+CWD="$PWD"
+CLAUDE_BIN="$(command -v claude || echo claude)"
+
+# Walk up the process tree to find the ancestor 'claude' process. Match the
+# basename EXACTLY so we don't match unrelated processes like 'claude-helper'.
+# kill -0 (used inside the resume script) only needs signal permission, so the
+# *wait* is reliable even where ps is restricted; this detection is best-effort.
+OLD_PID=""
+pid="$PPID"
+guard=0
+while [ -n "$pid" ] && [ "$pid" -gt 1 ] && [ "$guard" -lt 25 ]; do
+  comm="$(ps -o comm= -p "$pid" 2>/dev/null || true)"
+  case "${comm##*/}" in
+    claude) OLD_PID="$pid"; break ;;
+  esac
+  pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
+  guard=$((guard + 1))
+done
+
+# Write the resume script the new tmux window will run. It is always invoked as
+# `bash <script>`, so no shebang is needed.
+SCRIPT="${CLAUDE_TMPDIR:-${TMPDIR:-/tmp}}/teleport-resume-${SID}.sh"
+{
+  if [ -n "$OLD_PID" ]; then
+    printf 'echo "Waiting for the original Claude session (PID %s) to exit, then resuming here..."\n' "$OLD_PID"
+    printf 'while kill -0 %s 2>/dev/null; do sleep 0.5; done\n' "$OLD_PID"
+    # Brief pause narrows the PID-reuse / TOCTOU window before we start writing
+    # to the same transcript the old process just released.
+    printf 'sleep 1\n'
+  fi
+  printf 'cd %q || exit 1\n' "$CWD"
+  # No `exec`: keep the pane open if resume fails so the error is visible.
+  printf '%q --resume %q\n' "$CLAUDE_BIN" "$SID"
+  printf 'ec=$?\n'
+  printf '[ "$ec" -ne 0 ] && { echo "claude --resume exited with $ec. Press Enter to close."; read -r _; }\n'
+} > "$SCRIPT"
+chmod +x "$SCRIPT"
+
+echo "SESSION_ID=$SID"
+echo "OLD_PID=${OLD_PID:-<not-detected>}"
+echo "RESUME_SCRIPT=$SCRIPT"
+echo "INSIDE_TMUX=${TMUX:+yes}"
+echo "--- existing tmux sessions ---"
+tmux list-sessions -F '#{session_name}' 2>/dev/null || echo "<none>"
+```
+
+Capture from the output: `RESUME_SCRIPT` (path), whether `OLD_PID` was detected
+(`AUTO=yes` if it is a number, `AUTO=no` if `<not-detected>`), whether we're
+`INSIDE_TMUX`, and the list of existing sessions.
+
+## Step 2: Resolve the target session
+
+- If the user passed an argument (`$ARGUMENTS`), use it as the target session name.
+- Otherwise, look at the existing sessions from Step 1:
+  - If there are existing sessions, use **AskUserQuestion** to let the user pick
+    one, or choose "Create a new session". Offer a sensible default name for a
+    new session based on the current directory: `claude-<basename of CWD>`.
+  - If there are no sessions at all, default to creating `claude-<basename of CWD>`
+    (still confirm the name with AskUserQuestion if the user gave no argument).
+
+Set `TARGET` to the chosen session name.
+
+## Step 3: Create the window and arm the resume
+
+Run this block, substituting only these simple, low-risk values: `__TARGET__`
+(the session name), `__SCRIPT__` (the `RESUME_SCRIPT` path from Step 1), and
+`__AUTO__` (`yes` or `no` from Step 1). The window's working directory is set by
+the resume script's own `cd`, so no path needs substituting here.
+
+```bash
+set -euo pipefail
+TARGET='__TARGET__'
+SCRIPT='__SCRIPT__'
+AUTO='__AUTO__'
+
+# Create the window and capture its index so send-keys targets THIS window,
+# not whatever window happens to be active in the session.
+if tmux has-session -t "$TARGET" 2>/dev/null; then
+  WIN="$(tmux new-window -t "$TARGET" -n claude -P -F '#{window_index}')"
+else
+  tmux new-session -d -s "$TARGET" -n claude
+  WIN="$(tmux list-windows -t "$TARGET" -F '#{window_index}' | head -n1)"
+fi
+PANE="${TARGET}:${WIN}"
+
+if [ "$AUTO" = yes ]; then
+  # Auto-wait: the script waits for the old process to exit, then resumes. This
+  # prevents two processes appending to the same transcript .jsonl at once.
+  tmux send-keys -t "$PANE" "bash $(printf %q "$SCRIPT")" C-m
+  echo "ARMED_AUTO_WAIT pane=$PANE"
+else
+  # Graceful degradation (PID not detected): pre-type the launch but do NOT run
+  # it, so the user can close the old terminal first, then press Enter.
+  tmux send-keys -t "$PANE" "bash $(printf %q "$SCRIPT")"
+  echo "ARMED_MANUAL pane=$PANE"
+fi
+```
+
+## Step 4: Tell the user what to do
+
+Based on the output:
+
+- If **auto-wait** was armed (`ARMED_AUTO_WAIT`):
+  1. If `INSIDE_TMUX` was `yes`: `tmux switch-client -t <TARGET>`
+     Otherwise, from any terminal: `tmux attach -t <TARGET>`
+  2. The new window shows "Waiting for the original Claude session to exit…".
+  3. **Close / exit the original terminal** (or `Ctrl-C` then exit the old
+     Claude). The new window will automatically launch `claude --resume` and
+     pick the conversation back up.
+
+- If **manual** was armed (`ARMED_MANUAL` — PID not detected):
+  1. Attach/switch to `<TARGET>` as above.
+  2. The resume command is pre-typed but not running.
+  3. **First** close the original terminal, **then** press Enter in the new
+     window to start the resumed session (this ordering avoids transcript
+     corruption from two processes writing at once).
+
+Keep the final message concise: the attach/switch command, and the reminder to
+close the old terminal.

--- a/plugins/workflow/scripts/teleport-tmux.sh
+++ b/plugins/workflow/scripts/teleport-tmux.sh
@@ -49,9 +49,15 @@ probe_tmux() {
   # `var=$(failing)` would abort the script under errexit).
   if TMUX_OUT="$(tmux list-sessions -F '#{session_name}' 2>&1)"; then
     TMUX_STATUS=ok
-  elif [[ "$TMUX_OUT" == *"no server running"* ]]; then
+  elif [[ "$TMUX_OUT" == *"no server running"* || "$TMUX_OUT" == *"No such file or directory"* ]]; then
+    # No server started yet. tmux's wording varies by platform/version:
+    #   Linux / older tmux: "no server running on <socket>"
+    #   macOS tmux 3.x:     "error connecting to <socket> (No such file or directory)"
+    # `tmux new-session` starts one on demand, so this is benign — not a block.
     TMUX_STATUS=no-server
   else
+    # Anything else — notably "(Operation not permitted)" from a sandbox
+    # blocking the socket — is a real connection failure we must surface.
     TMUX_STATUS=blocked
   fi
 }

--- a/plugins/workflow/scripts/teleport-tmux.sh
+++ b/plugins/workflow/scripts/teleport-tmux.sh
@@ -38,23 +38,22 @@ require_tmux() {
     || die "tmux is not installed. Install it with: brew install tmux"
 }
 
-# Probe the tmux server socket so a sandbox/permission failure surfaces clearly
-# rather than masquerading as "no sessions". Echoes one of:
-#   ok            - server reachable, sessions may or may not exist
-#   no-server     - tmux works but no server/sessions yet (benign)
-#   blocked:<msg> - socket connection refused (likely sandbox); <msg> is detail
-tmux_probe() {
-  local out rc
-  out="$(tmux list-sessions -F '#{session_name}' 2>&1)"; rc=$?
-  if [ "$rc" -eq 0 ]; then
-    printf 'ok\n%s\n' "$out"
-    return 0
+# Query the tmux server once and classify the result, so a sandbox/permission
+# failure surfaces clearly rather than masquerading as "no sessions". Sets two
+# globals (bash's idiom for returning more than one value):
+#   TMUX_STATUS = ok | no-server | blocked
+#   TMUX_OUT    = raw output — session names when ok, error detail when blocked
+probe_tmux() {
+  # Assign inside the `if` condition: this both captures the command
+  # substitution's exit status directly and exempts it from `set -e` (a bare
+  # `var=$(failing)` would abort the script under errexit).
+  if TMUX_OUT="$(tmux list-sessions -F '#{session_name}' 2>&1)"; then
+    TMUX_STATUS=ok
+  elif [[ "$TMUX_OUT" == *"no server running"* ]]; then
+    TMUX_STATUS=no-server
+  else
+    TMUX_STATUS=blocked
   fi
-  if printf '%s' "$out" | grep -qi 'no server running'; then
-    echo "no-server"
-    return 0
-  fi
-  printf 'blocked:%s\n' "$out"
 }
 
 # ---------------------------------------------------------------------------
@@ -118,19 +117,16 @@ do_discover() {
   echo "INSIDE_TMUX=${TMUX:+yes}"
   echo "--- existing tmux sessions ---"
 
-  local probe status
-  probe="$(tmux_probe)"
-  status="$(printf '%s' "$probe" | head -n1)"
-  case "$status" in
+  probe_tmux
+  case "$TMUX_STATUS" in
     ok)
-      # Lines after the first are the session names (may be empty).
-      printf '%s\n' "$probe" | tail -n +2 | sed '/^$/d' || true
+      [ -n "$TMUX_OUT" ] && printf '%s\n' "$TMUX_OUT" || true
       ;;
     no-server)
       echo "<none>"
       ;;
-    blocked:*)
-      echo "ERROR_LISTING_SESSIONS: ${status#blocked:}"
+    blocked)
+      echo "ERROR_LISTING_SESSIONS: $TMUX_OUT"
       echo "(This usually means the sandbox is blocking the tmux socket. Re-run"
       echo " with the sandbox disabled, or allowlist the tmux socket directory.)"
       ;;
@@ -158,14 +154,10 @@ do_arm() {
 
   # Surface a blocked socket before we try to create windows, so the failure is
   # legible instead of an opaque tmux error mid-way.
-  local probe status
-  probe="$(tmux_probe)"
-  status="$(printf '%s' "$probe" | head -n1)"
-  case "$status" in
-    blocked:*)
-      die "tmux socket is blocked (${status#blocked:}). Re-run with the sandbox disabled, or allowlist the tmux socket directory."
-      ;;
-  esac
+  probe_tmux
+  if [ "$TMUX_STATUS" = blocked ]; then
+    die "tmux socket is blocked ($TMUX_OUT). Re-run with the sandbox disabled, or allowlist the tmux socket directory."
+  fi
 
   # Create the window and capture its index so send-keys targets THIS window,
   # not whatever window happens to be active in the session.

--- a/plugins/workflow/scripts/teleport-tmux.sh
+++ b/plugins/workflow/scripts/teleport-tmux.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# Teleport the current Claude session into a tmux window.
+#
+# macOS cannot move a live process's controlling terminal (no working reptyr),
+# so this does NOT move the running process. Instead it arms a new tmux window
+# to RESUME the current conversation from disk (claude --resume <session-id>)
+# once the old process exits. The transcript is persisted per turn, so
+# everything committed transfers; only truly in-flight work is lost.
+#
+# Two modes:
+#   teleport-tmux.sh --discover
+#       Detect the old claude PID, write the resume script, and print state +
+#       the existing tmux session list. Distinguishes "no tmux server running"
+#       from a real error (e.g. a sandbox blocking the tmux socket) instead of
+#       silently reporting "<none>".
+#
+#   teleport-tmux.sh --arm --target <session> --script <path> [--auto yes|no]
+#       Create a 'claude' window in <session> (creating the session if needed)
+#       and arm it to run <path>. With --auto yes the resume runs immediately
+#       (it waits for the old PID internally); with --auto no it is pre-typed
+#       but not executed, so the user can close the old terminal first.
+#
+# IMPORTANT (sandbox): tmux talks to its server over a Unix socket (e.g.
+# /private/tmp/tmux-501/default) that lives outside the default Claude Code
+# sandbox's writable allowlist. Run this script with the sandbox DISABLED, or
+# allowlist the tmux socket directory — otherwise every tmux call fails with
+# "error connecting to ... (Operation not permitted)".
+
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Shared preconditions
+# ---------------------------------------------------------------------------
+require_tmux() {
+  command -v tmux >/dev/null 2>&1 \
+    || die "tmux is not installed. Install it with: brew install tmux"
+}
+
+# Probe the tmux server socket so a sandbox/permission failure surfaces clearly
+# rather than masquerading as "no sessions". Echoes one of:
+#   ok            - server reachable, sessions may or may not exist
+#   no-server     - tmux works but no server/sessions yet (benign)
+#   blocked:<msg> - socket connection refused (likely sandbox); <msg> is detail
+tmux_probe() {
+  local out rc
+  out="$(tmux list-sessions -F '#{session_name}' 2>&1)"; rc=$?
+  if [ "$rc" -eq 0 ]; then
+    printf 'ok\n%s\n' "$out"
+    return 0
+  fi
+  if printf '%s' "$out" | grep -qi 'no server running'; then
+    echo "no-server"
+    return 0
+  fi
+  printf 'blocked:%s\n' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# --discover
+# ---------------------------------------------------------------------------
+do_discover() {
+  require_tmux
+
+  # CLAUDE_CODE_SESSION_ID is an internal Claude Code env var (not in
+  # `claude --help`); it holds the session ID we resume. Fail loudly if it ever
+  # stops being exported.
+  local SID="${CLAUDE_CODE_SESSION_ID:-}"
+  [ -n "$SID" ] || die "CLAUDE_CODE_SESSION_ID is not set; cannot determine which session to resume."
+
+  local CWD="$PWD"
+  local CLAUDE_BIN
+  CLAUDE_BIN="$(command -v claude || echo claude)"
+
+  # Walk up the process tree to find the ancestor 'claude' process. Match the
+  # basename EXACTLY so we don't match 'claude-helper' etc. kill -0 (used in the
+  # resume script) only needs signal permission, so the *wait* is reliable even
+  # where ps is restricted; this detection is best-effort.
+  local OLD_PID="" pid="$PPID" guard=0 comm
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ] && [ "$guard" -lt 25 ]; do
+    comm="$(ps -o comm= -p "$pid" 2>/dev/null || true)"
+    case "${comm##*/}" in
+      claude) OLD_PID="$pid"; break ;;
+    esac
+    pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
+    guard=$((guard + 1))
+  done
+
+  # Write the resume script the new tmux window will run. Always invoked as
+  # `bash <script>`, so no shebang is needed.
+  local SCRIPT="${CLAUDE_TMPDIR:-${TMPDIR:-/tmp}}/teleport-resume-${SID}.sh"
+  {
+    if [ -n "$OLD_PID" ]; then
+      printf 'echo "Waiting for the original Claude session (PID %s) to exit, then resuming here..."\n' "$OLD_PID"
+      printf 'while kill -0 %s 2>/dev/null; do sleep 0.5; done\n' "$OLD_PID"
+      # Brief pause narrows the PID-reuse / TOCTOU window before we start
+      # writing to the same transcript the old process just released.
+      printf 'sleep 1\n'
+    fi
+    printf 'cd %q || exit 1\n' "$CWD"
+    # No `exec`: keep the pane open if resume fails so the error is visible.
+    printf '%q --resume %q\n' "$CLAUDE_BIN" "$SID"
+    printf 'ec=$?\n'
+    printf '[ "$ec" -ne 0 ] && { echo "claude --resume exited with $ec. Press Enter to close."; read -r _; }\n'
+  } > "$SCRIPT"
+  chmod +x "$SCRIPT"
+
+  echo "SESSION_ID=$SID"
+  if [ -n "$OLD_PID" ]; then
+    echo "OLD_PID=$OLD_PID"
+    echo "AUTO=yes"
+  else
+    echo "OLD_PID=<not-detected>"
+    echo "AUTO=no"
+  fi
+  echo "RESUME_SCRIPT=$SCRIPT"
+  echo "INSIDE_TMUX=${TMUX:+yes}"
+  echo "--- existing tmux sessions ---"
+
+  local probe status
+  probe="$(tmux_probe)"
+  status="$(printf '%s' "$probe" | head -n1)"
+  case "$status" in
+    ok)
+      # Lines after the first are the session names (may be empty).
+      printf '%s\n' "$probe" | tail -n +2 | sed '/^$/d' || true
+      ;;
+    no-server)
+      echo "<none>"
+      ;;
+    blocked:*)
+      echo "ERROR_LISTING_SESSIONS: ${status#blocked:}"
+      echo "(This usually means the sandbox is blocking the tmux socket. Re-run"
+      echo " with the sandbox disabled, or allowlist the tmux socket directory.)"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# --arm
+# ---------------------------------------------------------------------------
+do_arm() {
+  local TARGET="" SCRIPT="" AUTO="no"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --target) TARGET="${2:-}"; shift 2 ;;
+      --script) SCRIPT="${2:-}"; shift 2 ;;
+      --auto)   AUTO="${2:-no}"; shift 2 ;;
+      *) die "unknown --arm argument: $1" ;;
+    esac
+  done
+
+  require_tmux
+  [ -n "$TARGET" ] || die "--arm requires --target <session>"
+  [ -n "$SCRIPT" ] || die "--arm requires --script <path>"
+  [ -f "$SCRIPT" ] || die "resume script not found: $SCRIPT"
+
+  # Surface a blocked socket before we try to create windows, so the failure is
+  # legible instead of an opaque tmux error mid-way.
+  local probe status
+  probe="$(tmux_probe)"
+  status="$(printf '%s' "$probe" | head -n1)"
+  case "$status" in
+    blocked:*)
+      die "tmux socket is blocked (${status#blocked:}). Re-run with the sandbox disabled, or allowlist the tmux socket directory."
+      ;;
+  esac
+
+  # Create the window and capture its index so send-keys targets THIS window,
+  # not whatever window happens to be active in the session.
+  local WIN PANE
+  if tmux has-session -t "$TARGET" 2>/dev/null; then
+    WIN="$(tmux new-window -t "$TARGET" -n claude -P -F '#{window_index}')"
+  else
+    tmux new-session -d -s "$TARGET" -n claude
+    WIN="$(tmux list-windows -t "$TARGET" -F '#{window_index}' | head -n1)"
+  fi
+  PANE="${TARGET}:${WIN}"
+
+  if [ "$AUTO" = yes ]; then
+    # Auto-wait: the resume script waits for the old process to exit, then
+    # resumes. Prevents two processes appending to the same transcript at once.
+    tmux send-keys -t "$PANE" "bash $(printf %q "$SCRIPT")" C-m
+    echo "ARMED_AUTO_WAIT pane=$PANE"
+  else
+    # Graceful degradation (PID not detected): pre-type the launch but do NOT
+    # run it, so the user can close the old terminal first, then press Enter.
+    tmux send-keys -t "$PANE" "bash $(printf %q "$SCRIPT")"
+    echo "ARMED_MANUAL pane=$PANE"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+case "${1:-}" in
+  --discover) shift; do_discover "$@" ;;
+  --arm)      shift; do_arm "$@" ;;
+  *) die "usage: teleport-tmux.sh --discover | --arm --target <session> --script <path> [--auto yes|no]" ;;
+esac


### PR DESCRIPTION
## What

`/workflow:teleport-tmux` moves the current Claude session into a tmux window so you can close the terminal you accidentally started Claude in without losing the conversation. macOS can't relocate a live process's terminal, so instead it arms a new tmux window to `claude --resume <session-id>` the moment the old process exits.

This PR extracts the command's inline bash into a packaged, version-controlled script and fixes a bug where existing tmux sessions could silently appear empty.

## Changes

- **New `plugins/workflow/scripts/teleport-tmux.sh`** with two modes:
  - `--discover` — detects the old `claude` process, writes the resume script, and lists existing sessions. It now distinguishes "no tmux server running" from a blocked socket, so a permission failure surfaces as a clear error instead of looking like "no sessions."
  - `--arm` — creates the resume window and arms it (auto-wait if the old process was detected, otherwise pre-typed for manual launch).
- **`commands/teleport-tmux.md`** slimmed to discover → ask → arm → relay, and documents that its bash blocks must run with the sandbox disabled (tmux's socket lives outside the default sandbox allowlist).
- **`plugin.json`** bumped to `2.17.0`.