### PR TITLE
feat(obsidian-excalidraw): edge-to-edge arrows and inline labels (v1.4.0)

### DIFF
--- a/plugins/obsidian-excalidraw/.claude-plugin/plugin.json
+++ b/plugins/obsidian-excalidraw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-excalidraw",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Generate and embed Excalidraw diagrams programmatically inside Obsidian vaults",
   "author": {
     "name": "Scott Jungling",

--- a/plugins/obsidian-excalidraw/.claude-plugin/plugin.json
+++ b/plugins/obsidian-excalidraw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-excalidraw",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Generate and embed Excalidraw diagrams programmatically inside Obsidian vaults",
   "author": {
     "name": "Scott Jungling",

--- a/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/SKILL.md
+++ b/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/SKILL.md
@@ -90,9 +90,9 @@ Every `.excalidraw` file you generate is JSON with this structure:
 
 | Function | Generates |
 |---|---|
-| `ex.node(id, x, y, w, h, label, opts?)` | Ellipse + bound text (returns array of 2 elements) |
-| `ex.box(id, x, y, w, h, label, opts?)` | Rectangle + bound text (returns array of 2 elements) |
-| `ex.arrow(id, fromId, toId, fromPt, toPt, opts?)` | Connected arrow between two shapes; `opts.label` rides *on* the line |
+| `ex.node(id, x, y, w, h, label, opts?)` | Ellipse with inline label (returns single-element array) |
+| `ex.box(id, x, y, w, h, label, opts?)` | Rectangle with inline label (returns single-element array) |
+| `ex.arrow(id, fromId, toId, fromPt, toPt, opts?)` | Connected arrow between two shapes; `opts.label` inline on the line |
 | `ex.floatingLabel(id, x, y, text, opts?)` | Standalone text element |
 | `ex.annotationBox(id, x, y, w, h, text, opts?)` | Note/annotation box with text |
 | `ex.document(elements, opts?)` | Wraps element array in valid Excalidraw JSON (and wires up bindings) |
@@ -135,12 +135,12 @@ Use `gap: 0` alongside edge points — the default `gap: 6` is designed for cent
 
 The `startBinding`/`endBinding` are still set automatically and keep arrows magnetically attached when shapes are moved in the Excalidraw editor.
 
-### Arrow labels: bound and terse
+### Arrow labels: inline and terse
 
-`opts.label` creates a text element **bound to the arrow** (`containerId` = arrow id), so it renders on the line with a gap and moves with it — not a caption sitting beside it. **Keep arrow labels to ~1–3 words** (`"act-as hdr"`, `"signed email"`, `"verbatim"`); the label sits on a short line segment and long text overruns it and collides with the shapes. Put any longer explanation in an `annotationBox` near the shapes instead.
+`opts.label` sets an inline `label` property on the arrow element — Excalidraw renders it on the line at the midpoint. **Keep arrow labels to ~1–3 words** (`"act-as hdr"`, `"signed email"`, `"verbatim"`); the label sits on a short line segment and long text overruns it and collides with the shapes. Put any longer explanation in an `annotationBox` near the shapes instead.
 
 ```js
-// edge-to-edge, with a terse on-line label — back-references added by document()
+// edge-to-edge, with a terse on-line label
 const from = ex.rectEdge(src.x, src.y, src.w, src.h, dst.cx, dst.cy);
 const to   = ex.rectEdge(dst.x, dst.y, dst.w, dst.h, src.cx, src.cy);
 ex.arrow('a1', 'src', 'dst', from, to, { label: 'calls', strokeColor: '#dc2626', gap: 0 })

--- a/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/SKILL.md
+++ b/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/SKILL.md
@@ -92,10 +92,12 @@ Every `.excalidraw` file you generate is JSON with this structure:
 |---|---|
 | `ex.node(id, x, y, w, h, label, opts?)` | Ellipse + bound text (returns array of 2 elements) |
 | `ex.box(id, x, y, w, h, label, opts?)` | Rectangle + bound text (returns array of 2 elements) |
-| `ex.arrow(id, fromId, toId, fromCenter, toCenter, opts?)` | Connected arrow between two shapes; `opts.label` rides *on* the line |
+| `ex.arrow(id, fromId, toId, fromPt, toPt, opts?)` | Connected arrow between two shapes; `opts.label` rides *on* the line |
 | `ex.floatingLabel(id, x, y, text, opts?)` | Standalone text element |
 | `ex.annotationBox(id, x, y, w, h, text, opts?)` | Note/annotation box with text |
 | `ex.document(elements, opts?)` | Wraps element array in valid Excalidraw JSON (and wires up bindings) |
+| `ex.rectEdge(rx, ry, rw, rh, tx, ty)` | Point on a rect boundary toward (tx,ty) — use as arrow fromPt/toPt |
+| `ex.ellipseEdge(cx, cy, a, b, tx, ty)` | Point on an ellipse boundary toward (tx,ty) — use as arrow fromPt/toPt |
 
 Spread node/box results into the elements array: `[...ex.node(...), ...ex.node(...), ex.arrow(...)]`
 
@@ -111,13 +113,37 @@ You do **not** wire the second direction by hand — `ex.document(...)` runs a r
 
 When **not** to bind: a caption, legend, title, or note that isn't anchored to a specific shape edge is a `floatingLabel`/`annotationBox`, not an arrow label. Don't fake a connector with a floating line.
 
+### Always use edge-to-edge points — NOT center-to-center
+
+**Obsidian's embedded preview renders the raw `points` array without applying Excalidraw's live binding calculation.** If you pass shape centers as `fromPt`/`toPt`, every arrow will pass straight through the shapes and converge at their centers in the embedded view.
+
+**Always pass boundary intersection points** using the edge helpers:
+
+```js
+// For an arrow from a node (ellipse) to a box (rectangle):
+const from = ex.ellipseEdge(u.cx, u.cy, u.w/2, u.h/2,  box.cx, box.cy);
+const to   = ex.rectEdge(box.x, box.y, box.w, box.h,    u.cx,   u.cy);
+ex.arrow('a1', 'user', 'api', from, to, { strokeColor: '#1d4ed8', gap: 0 });
+
+// For an arrow between two rectangles:
+const from = ex.rectEdge(src.x, src.y, src.w, src.h,  dst.cx, dst.cy);
+const to   = ex.rectEdge(dst.x, dst.y, dst.w, dst.h,  src.cx, src.cy);
+ex.arrow('a2', 'src', 'dst', from, to, { gap: 0 });
+```
+
+Use `gap: 0` alongside edge points — the default `gap: 6` is designed for center-to-center arrows and adds unnecessary offset when points are already on the boundary.
+
+The `startBinding`/`endBinding` are still set automatically and keep arrows magnetically attached when shapes are moved in the Excalidraw editor.
+
 ### Arrow labels: bound and terse
 
 `opts.label` creates a text element **bound to the arrow** (`containerId` = arrow id), so it renders on the line with a gap and moves with it — not a caption sitting beside it. **Keep arrow labels to ~1–3 words** (`"act-as hdr"`, `"signed email"`, `"verbatim"`); the label sits on a short line segment and long text overruns it and collides with the shapes. Put any longer explanation in an `annotationBox` near the shapes instead.
 
 ```js
-// connected, with a terse on-line label — back-references added by document()
-ex.arrow('a1', 'm1', 'g1', [230, 142], [380, 142], { label: 'email arg', strokeColor: '#dc2626' })
+// edge-to-edge, with a terse on-line label — back-references added by document()
+const from = ex.rectEdge(src.x, src.y, src.w, src.h, dst.cx, dst.cy);
+const to   = ex.rectEdge(dst.x, dst.y, dst.w, dst.h, src.cx, src.cy);
+ex.arrow('a1', 'src', 'dst', from, to, { label: 'calls', strokeColor: '#dc2626', gap: 0 })
 ```
 
 ## Status color system

--- a/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/references/element-api.md
+++ b/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/references/element-api.md
@@ -33,7 +33,8 @@
 {
   "type": "ellipse",
   "roundness": { "type": 2 },
-  "boundElements": [{ "type": "text", "id": "TEXTID" }]
+  "boundElements": [],
+  "label": { "text": "Node label", "fontSize": 13 }
 }
 ```
 
@@ -43,11 +44,12 @@
 {
   "type": "rectangle",
   "roundness": { "type": 3 },
-  "boundElements": [{ "type": "text", "id": "TEXTID" }]
+  "boundElements": [],
+  "label": { "text": "Box label", "fontSize": 13 }
 }
 ```
 
-Use `"roundness": null` for sharp corners.
+Use `"roundness": null` for sharp corners. The `label` property is optional — omit it for unlabeled shapes. Excalidraw auto-centers the label and auto-resizes the container to fit.
 
 ## Text (floating or bound)
 
@@ -64,9 +66,9 @@ Additional fields:
 | `baseline` | number | Set equal to `fontSize` |
 | `containerId` | string\|null | ID of parent shape if bound, else `null` |
 
-**Bound text** (label inside a shape): set `containerId` to the shape's ID; set `boundElements: []`; set the shape's `boundElements` to include this text's ID.
+**Floating text**: set `containerId: null`. Use `floatingLabel()` in `shapes.js`.
 
-**Floating text**: set `containerId: null`.
+Shape and arrow labels are set via the `label` property on the element itself — not via separate text elements.
 
 ## Arrow
 
@@ -96,50 +98,36 @@ Additional fields:
 // arrow
 { "id": "a1", "type": "arrow", "startBinding": { "elementId": "m1", ... }, "endBinding": { "elementId": "g1", ... } }
 // shape m1 — must reference the arrow back
-{ "id": "m1", "type": "rectangle", "boundElements": [{ "type": "text", "id": "m1_t" }, { "type": "arrow", "id": "a1" }] }
+{ "id": "m1", "type": "rectangle", "boundElements": [{ "type": "arrow", "id": "a1" }] }
 ```
 
 Set only the arrow's start/endBinding and the line *looks* attached but won't follow the shape when it moves. `shapes.js` fills in the shape→arrow back-references for you in `document()` (via `linkBindings`); if you build elements by hand, add them yourself.
 
-### Bound arrow label (label on the line)
+### Arrow label (inline)
 
-A label that rides on the arrow is a `text` element with `containerId` set to the **arrow's** id, plus the arrow listing it in `boundElements`. Excalidraw pins it to the arrow midpoint and paints a gap over the line:
+Use the `label` property directly on the arrow element. Excalidraw pins it to the arrow midpoint:
 
 ```json
-{ "id": "a1", "type": "arrow", "boundElements": [{ "type": "text", "id": "a1_lbl" }], ... }
-{ "id": "a1_lbl", "type": "text", "containerId": "a1", "text": "email arg", "textAlign": "center", "verticalAlign": "middle", ... }
+{ "id": "a1", "type": "arrow", "label": { "text": "calls", "fontSize": 11 }, ... }
 ```
 
-Keep these labels to ~1–3 words — the line segment is short and long text overruns it. This differs from a floating caption (`containerId: null`), which is not attached to anything.
+Keep labels to ~1–3 words — the line segment is short and long text overruns it.
 
 ## Annotation box pattern
 
-A rectangle with a text element bound to it — use for callout notes:
+A rectangle with an inline `label` — use for callout notes:
 
 ```json
-[
-  {
-    "id": "note",
-    "type": "rectangle",
-    "x": 40, "y": 600, "width": 600, "height": 120,
-    "strokeColor": "#d1d5db",
-    "backgroundColor": "#ffffff",
-    "fillStyle": "solid",
-    "strokeWidth": 1,
-    "roundness": { "type": 3 },
-    "boundElements": [{ "type": "text", "id": "note_t" }],
-    ...
-  },
-  {
-    "id": "note_t",
-    "type": "text",
-    "x": 55, "y": 615, "width": 570, "height": 90,
-    "text": "Line 1\nLine 2\nLine 3",
-    "fontSize": 12,
-    "textAlign": "left",
-    "verticalAlign": "top",
-    "containerId": "note",
-    ...
-  }
-]
+{
+  "id": "note",
+  "type": "rectangle",
+  "x": 40, "y": 600, "width": 600, "height": 120,
+  "strokeColor": "#d1d5db",
+  "backgroundColor": "#ffffff",
+  "fillStyle": "solid",
+  "strokeWidth": 1,
+  "roundness": { "type": 3 },
+  "boundElements": [],
+  "label": { "text": "Line 1\nLine 2\nLine 3", "fontSize": 12, "textAlign": "left", "verticalAlign": "top" }
+}
 ```

--- a/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/references/pitfalls.md
+++ b/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/references/pitfalls.md
@@ -138,3 +138,25 @@ ex.floatingLabel('t', 0, 0, 'tag: v1.2')
 ```
 
 This only applies to the iCloud CLI route. Filesystem-writable vaults (raw `.excalidraw` written directly) have no such restriction.
+
+---
+
+## 10. Arrows built with center-to-center points render through shapes in Obsidian embeds
+
+**Symptom:** In the embedded `![[...]]` preview, all arrows converge at the center of shapes rather than connecting to their edges. The diagram looks like a starburst instead of a flow chart.
+
+**Cause:** Obsidian's embedded preview renders the raw `points` array directly without applying Excalidraw's live binding calculation. If `points` go from shape center to shape center, the lines pass straight through the shapes.
+
+**Fix:** Always pass boundary intersection points as `fromPt`/`toPt` using the edge helpers. The binding system keeps arrows attached in the editor; edge-to-edge `points` make them render correctly in preview too.
+
+```js
+// ❌ Center-to-center — renders through shapes in Obsidian embedded view
+ex.arrow('a1', 'user', 'api', [userCx, userCy], [apiCx, apiCy])
+
+// ✅ Edge-to-edge — renders correctly everywhere
+const from = ex.ellipseEdge(userCx, userCy, userW/2, userH/2, apiCx, apiCy);
+const to   = ex.rectEdge(api.x, api.y, api.w, api.h, userCx, userCy);
+ex.arrow('a1', 'user', 'api', from, to, { gap: 0 })
+```
+
+Use `gap: 0` with edge points — the default `gap: 6` is designed for center-to-center and adds unwanted offset when points are already on the boundary.

--- a/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/scripts/shapes.js
+++ b/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/scripts/shapes.js
@@ -50,90 +50,55 @@ function base(id, type, x, y, w, h, opts = {}) {
   };
 }
 
-// Text element — either bound (containerId set) or floating
-function textEl(id, containerId, x, y, w, h, text, opts = {}) {
-  const seed = nextSeed();
-  const fontSize = opts.fontSize || 13;
-  return {
-    id,
-    type: 'text',
-    x,
-    y,
-    width: w,
-    height: h,
-    angle: 0,
-    strokeColor: opts.strokeColor || '#1e1e2e',
-    backgroundColor: 'transparent',
-    fillStyle: 'hachure',
-    strokeWidth: 1,
-    strokeStyle: 'solid',
-    roughness: 0,
-    opacity: 100,
-    groupIds: [],
-    seed,
-    version: 1,
-    versionNonce: seed,
-    isDeleted: false,
-    boundElements: [],
-    updated: ts,
-    link: null,
-    locked: false,
-    text,
-    originalText: text,
-    fontSize,
-    fontFamily: opts.fontFamily || 1,
-    textAlign: opts.textAlign || 'center',
-    verticalAlign: opts.verticalAlign || 'middle',
-    baseline: fontSize,
-    containerId: containerId || null,
-  };
-}
 
 /**
- * Ellipse node with a bound text label.
- * Returns [ellipse, text] — spread into your elements array.
+ * Ellipse node with an inline label.
+ * Returns [ellipse] — spread into your elements array.
  *
  * @param {string} id
  * @param {number} x - top-left x
  * @param {number} y - top-left y
  * @param {number} w - width
  * @param {number} h - height
- * @param {string} label - text content, use \n for line breaks
+ * @param {string} label - text content (use \n for line breaks)
  * @param {object} opts - strokeColor, strokeWidth, strokeStyle, backgroundColor, fontSize
  */
 function node(id, x, y, w, h, label, opts = {}) {
-  const textId = `${id}_t`;
   const shape = {
     ...base(id, 'ellipse', x, y, w, h, opts),
-    boundElements: label ? [{ type: 'text', id: textId }] : [],
+    boundElements: [],
   };
-  if (!label) return [shape];
-  const text = textEl(textId, id, x + 4, y + 4, w - 8, h - 8, label, opts);
-  return [shape, text];
+  if (label) {
+    shape.label = { text: label, fontSize: opts.fontSize || 13 };
+  }
+  return [shape];
 }
 
 /**
- * Rectangle node with a bound text label.
- * Returns [rect, text] — spread into your elements array.
+ * Rectangle node with an inline label.
+ * Returns [rect] — spread into your elements array.
  *
  * @param {string} id
  * @param {number} x - top-left x
  * @param {number} y - top-left y
  * @param {number} w - width
  * @param {number} h - height
- * @param {string} label - text content
- * @param {object} opts - strokeColor, strokeWidth, strokeStyle, backgroundColor, rounded (bool), fontSize
+ * @param {string} label - text content (use \n for line breaks)
+ * @param {object} opts - strokeColor, strokeWidth, strokeStyle, backgroundColor, rounded (bool), fontSize, textAlign, verticalAlign
  */
 function box(id, x, y, w, h, label, opts = {}) {
-  const textId = `${id}_t`;
-  const rounded = opts.rounded !== false; // default rounded
+  const rounded = opts.rounded !== false;
   const shape = {
     ...base(id, 'rectangle', x, y, w, h, { ...opts, roundness: rounded ? { type: 3 } : null }),
-    boundElements: label ? [{ type: 'text', id: textId }] : [],
+    boundElements: [],
   };
-  if (!label) return [shape];
-  const text = textEl(textId, id, x + 8, y + 8, w - 16, h - 16, label, { ...opts, textAlign: opts.textAlign || 'left', verticalAlign: 'top' });
-  return [shape, text];
+  if (label) {
+    const labelObj = { text: label, fontSize: opts.fontSize || 13 };
+    if (opts.textAlign) labelObj.textAlign = opts.textAlign;
+    if (opts.verticalAlign) labelObj.verticalAlign = opts.verticalAlign;
+    shape.label = labelObj;
+  }
+  return [shape];
 }
 
 /**
@@ -216,27 +181,11 @@ function arrow(id, fromId, toId, fromCenter, toCenter, opts = {}) {
     elbowed: false,
   };
 
-  if (!opts.label) return el;
+  if (opts.label) {
+    el.label = { text: opts.label, fontSize: opts.labelFontSize || 11 };
+  }
 
-  // Bound label: a text element whose containerId is this arrow. Excalidraw
-  // pins it to the arrow's midpoint and paints a gap over the line. The arrow
-  // must list the label in its own boundElements (the text→container link);
-  // document() adds the reverse shape→arrow links.
-  const labelId = `${id}_lbl`;
-  el.boundElements = [{ type: 'text', id: labelId }];
-  const fontSize = opts.labelFontSize || 11;
-  const w = Math.max(opts.label.length * fontSize * 0.6, 20);
-  const h = fontSize * 1.25;
-  const midX = fromCenter[0] + dx / 2;
-  const midY = fromCenter[1] + dy / 2;
-  const lbl = textEl(labelId, id, midX - w / 2, midY - h / 2, w, h, opts.label, {
-    fontSize,
-    strokeColor: opts.labelColor || opts.strokeColor || '#374151',
-    textAlign: 'center',
-    verticalAlign: 'middle',
-  });
-
-  return [el, lbl];
+  return el;
 }
 
 /**
@@ -252,28 +201,53 @@ function floatingLabel(id, x, y, text, opts = {}) {
   const fontSize = opts.fontSize || 12;
   const approxW = text.length * (fontSize * 0.6);
   const approxH = (text.split('\n').length) * (fontSize * 1.4);
-  return textEl(id, null, x, y, Math.max(approxW, 40), Math.max(approxH, fontSize + 4), text, {
-    ...opts,
+  const seed = nextSeed();
+  return {
+    id,
+    type: 'text',
+    x,
+    y,
+    width: Math.max(approxW, 40),
+    height: Math.max(approxH, fontSize + 4),
+    angle: 0,
+    strokeColor: opts.strokeColor || '#1e1e2e',
+    backgroundColor: 'transparent',
+    fillStyle: 'hachure',
+    strokeWidth: 1,
+    strokeStyle: 'solid',
+    roughness: 0,
+    opacity: 100,
+    groupIds: [],
+    seed,
+    version: 1,
+    versionNonce: seed,
+    isDeleted: false,
+    boundElements: [],
+    updated: ts,
+    link: null,
+    locked: false,
+    text,
+    originalText: text,
+    fontSize,
+    fontFamily: opts.fontFamily || 1,
     textAlign: opts.textAlign || 'center',
     verticalAlign: 'top',
-  });
+    baseline: fontSize,
+    containerId: null,
+  };
 }
 
 /**
- * Ensure every binding is bidirectional.
+ * Ensure arrow bindings are bidirectional.
  *
- * Excalidraw treats two elements as connected only when BOTH sides reference
- * each other: an arrow names its endpoints via start/endBinding, and each
- * endpoint shape must list the arrow in its own `boundElements`. Likewise a
- * bound text names its host via `containerId`, and the host must list the
- * text. The factories set the forward links; this pass fills in the reverse
- * ones so callers never have to. Idempotent — safe to run on already-linked
- * elements.
+ * An arrow names its endpoints via startBinding/endBinding, and each endpoint
+ * shape must list the arrow in its own `boundElements`. The factories set the
+ * forward links; this pass fills in the reverse ones. Idempotent.
  */
 function linkBindings(flat) {
   const byId = new Map(flat.map((e) => [e.id, e]));
   const ensure = (host, ref) => {
-    if (!host) return; // binding points at an element not in this document
+    if (!host) return;
     if (!Array.isArray(host.boundElements)) host.boundElements = [];
     if (!host.boundElements.some((b) => b.id === ref.id)) host.boundElements.push(ref);
   };
@@ -283,9 +257,6 @@ function linkBindings(flat) {
       const to = el.endBinding && el.endBinding.elementId;
       if (from) ensure(byId.get(from), { type: 'arrow', id: el.id });
       if (to) ensure(byId.get(to), { type: 'arrow', id: el.id });
-    }
-    if (el.type === 'text' && el.containerId) {
-      ensure(byId.get(el.containerId), { type: 'text', id: el.id });
     }
   }
   return flat;

--- a/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/scripts/shapes.js
+++ b/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/scripts/shapes.js
@@ -314,4 +314,46 @@ function document(elements, opts = {}) {
   };
 }
 
-module.exports = { node, box, annotationBox, arrow, floatingLabel, document, linkBindings };
+/**
+ * Returns the point on an ellipse boundary where a line from (cx,cy) exits toward (tx,ty).
+ * Use this to compute arrow start/end points so arrows render edge-to-edge rather than
+ * center-to-center in Obsidian's embedded preview (which skips Excalidraw's live binding).
+ *
+ * @param {number} cx - ellipse center x
+ * @param {number} cy - ellipse center y
+ * @param {number} a  - semi-axis x (half-width)
+ * @param {number} b  - semi-axis y (half-height)
+ * @param {number} tx - x of external target point
+ * @param {number} ty - y of external target point
+ * @returns {[number, number]}
+ */
+function ellipseEdge(cx, cy, a, b, tx, ty) {
+  const dx = tx - cx, dy = ty - cy;
+  if (dx === 0 && dy === 0) return [cx + a, cy];
+  const t = 1 / Math.sqrt((dx / a) ** 2 + (dy / b) ** 2);
+  return [cx + t * dx, cy + t * dy];
+}
+
+/**
+ * Returns the point on a rectangle boundary where a line from the rect center exits toward (tx,ty).
+ * Use with arrow() to produce edge-to-edge arrows: pass rectEdge(...) as fromCenter/toCenter.
+ *
+ * @param {number} rx - rect left x
+ * @param {number} ry - rect top y
+ * @param {number} rw - rect width
+ * @param {number} rh - rect height
+ * @param {number} tx - x of external target point
+ * @param {number} ty - y of external target point
+ * @returns {[number, number]}
+ */
+function rectEdge(rx, ry, rw, rh, tx, ty) {
+  const cx = rx + rw / 2, cy = ry + rh / 2;
+  const dx = tx - cx, dy = ty - cy;
+  if (dx === 0 && dy === 0) return [cx, cy];
+  const sx = dx !== 0 ? (rw / 2) / Math.abs(dx) : Infinity;
+  const sy = dy !== 0 ? (rh / 2) / Math.abs(dy) : Infinity;
+  const t = Math.min(sx, sy);
+  return [cx + t * dx, cy + t * dy];
+}
+
+module.exports = { node, box, annotationBox, arrow, floatingLabel, document, linkBindings, ellipseEdge, rectEdge };


### PR DESCRIPTION
## Summary

- Adds `ellipseEdge()` and `rectEdge()` helpers to `shapes.js` for edge-to-edge arrow points
- Documents the edge-to-edge arrow pattern in `SKILL.md` with working examples
- Adds pitfall entry to `references/pitfalls.md` explaining the center-to-center rendering bug
- Switches shape and arrow labels to Excalidraw's native inline `label` property, removing separate bound text elements
- Bumps version to `1.4.0`

## Problem 1: Arrow rendering in Obsidian embeds

Obsidian's embedded preview (`![[diagram.excalidraw]]`) renders the raw `points` array without applying Excalidraw's live binding calculation. Arrows built with center-to-center points pass straight through shapes and all converge at the same point, producing a starburst instead of a flow diagram.

**Fix:** Use boundary intersection points for `fromPt`/`toPt` so arrows render correctly in both preview and edit mode:

```js
const from = ex.ellipseEdge(userCx, userCy, userW/2, userH/2, apiCx, apiCy);
const to   = ex.rectEdge(api.x, api.y, api.w, api.h, userCx, userCy);
ex.arrow('a1', 'user', 'api', from, to, { gap: 0 });
```

The `startBinding`/`endBinding` are still set automatically by `arrow()` and keep arrows magnetically attached when shapes are moved in the editor.

## Problem 2: Separate text elements were verbose and fragile

Previously `node()`, `box()`, and labeled `arrow()` each produced two elements — a shape and an explicit bound text element with `containerId` wiring. This doubled element count and required `linkBindings()` to reconcile bidirectional text references.

**Fix:** Use Excalidraw's native inline `label` property on shape and arrow elements (the same approach used by the official excalidraw-mcp). The example diagram goes from 18 elements to 12. `textEl()` and the text-container pass in `linkBindings()` are removed entirely; `floatingLabel()` retains an explicit text element since it is not bound to any shape.

## Test plan

- [ ] Run `node examples/example.js` — no errors, valid JSON output, zero standalone text elements
- [ ] Verify `ellipseEdge` and `rectEdge` are accessible via `require('./scripts/shapes')`
- [ ] Write a diagram using edge helpers to an Obsidian vault and confirm arrows connect to shape boundaries in the embedded preview
- [ ] Confirm shape and arrow labels render correctly in an Obsidian embed