### PR TITLE
feat(technical-writer): add /save-to-obsidian command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,10 @@ Each plugin can contain:
 - Skill: `pdf-generation` - Generate a PDF book from a directory of ordered markdown chapters using pandoc and weasyprint. Includes print-optimized CSS, table of contents, and inter-chapter link resolution.
 - Command: `/technical-overview [output-dir]` - Create or update a comprehensive Beej's-Guide-style technical manual with parallel chapter writing via teammates, then generate a PDF
 - Command: `/walkthrough [path-to-source]` - Generate a code walkthrough using showboat
+- Command: `/save-to-obsidian [vault] [topic]` - Save the current spec/plan/session summary to Obsidian as a design note. Auto-discovers superpowers specs/plans or a Claude plan file (falls back to a conversation summary), resolves the target vault/folder/tag conventions from existing notes, then writes through `write-markdown-to-vault.js` (never the `Write` tool) since iCloud-synced vaults are TCC-protected against direct filesystem access.
 - Agent: `technical-writer.md` - Legacy agent implementation (prefer skill for automatic activation)
 - Agent: `obsidian-vault-manager.md` - Obsidian vault management specialist using obsidian-cli
+- Script: `skills/obsidian-vault-manager/scripts/write-markdown-to-vault.js` - Reliable CLI-based writer for markdown notes into iCloud-synced (or any) vault: chunks payloads under the CLI's ~10KB IPC ceiling, filters banner noise, retries transient errors, verifies via read-back. Must run unsandboxed.
 
 **git-tools** (`plugins/git-tools/`):
 - Skill: `git-bisect-debugging` - Systematic workflow for using git bisect to identify which commit introduced a bug. Supports automated test scripts, manual verification, and hybrid approaches with subagent architecture for isolated execution. Integrates with superpowers:systematic-debugging for root cause analysis.

--- a/plugins/technical-writer/.claude-plugin/plugin.json
+++ b/plugins/technical-writer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "technical-writer",
   "description": "Technical documentation specialist for README files, API docs, user guides, specifications, and release notes with Obsidian vault management",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "author": {
     "name": "Scott",
     "email": "scott.jungling@gmail.com"

--- a/plugins/technical-writer/commands/save-to-obsidian.md
+++ b/plugins/technical-writer/commands/save-to-obsidian.md
@@ -1,0 +1,116 @@
+---
+description: Save the current spec/plan/session summary to Obsidian as a design note
+argument-hint: [vault] [topic]
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+---
+
+Save the best available content from the current session into an Obsidian vault as a design note.
+
+Parse `$1` as an optional **vault** override and `$2` as an optional **topic** override (both optional — see resolution rules below). `$1`/`$2` are name/topic strings, not file paths — this command never takes an explicit source file; content is always auto-discovered from the session.
+
+**Vaults on iCloud storage cannot be written with the `Write` tool** — `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<vault>` is TCC-protected; only the Obsidian app (via the `obsidian` CLI) can touch it, even with the sandbox disabled. **Step 5 below always writes through the CLI — never write directly to a resolved vault path with the `Write` tool, even for a small note.** (`Write` is only used in this command to stage the note in a scratch temp file before handing it to the CLI script.)
+
+## Step 1: Discover content
+
+Run the discovery script, resolved relative to the plugin root:
+
+```bash
+DISCOVERY=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/discover-spec-content.sh" 2>&1)
+```
+
+If it exits non-zero, check stderr for `{"error": "..."}` and report the error (`jq not installed`, `not in a git repository`).
+
+Parse the JSON output:
+```bash
+SOURCE=$(echo "$DISCOVERY" | jq -r '.source')
+PRIMARY=$(echo "$DISCOVERY" | jq -r '.primary')
+SECONDARY=$(echo "$DISCOVERY" | jq -r '.secondary')
+SPECS=$(echo "$DISCOVERY" | jq -r '.candidates.specs[]' 2>/dev/null)
+PLANS=$(echo "$DISCOVERY" | jq -r '.candidates.plans[]' 2>/dev/null)
+```
+
+### `superpowers`
+If `PRIMARY` is non-empty, read it as `$BODY`.
+
+If `PRIMARY` is empty, multiple candidates need disambiguation — use `AskUserQuestion` with the `SPECS`/`PLANS` candidates to pick the file. Read the chosen file as `$BODY`.
+
+If `SECONDARY` is non-empty (a related plan), you may append a short "Implementation plan: `<path>`" reference line to the note rather than inlining the whole plan.
+
+### `claude-plan`
+`PRIMARY` already points to the plan file. Read it as `$BODY`.
+
+### `summary`
+No spec/plan files found. Write a markdown summary of the current conversation covering:
+- **Problem** — what prompted the session
+- **Decisions & rationale** — key choices made and why (this is the part worth keeping; skip anything derivable from re-reading the code)
+- **Approach** — architecture/implementation shape agreed on
+- **Open questions** — anything unresolved
+
+Use this as `$BODY`.
+
+## Step 2: Resolve the vault
+
+```bash
+obsidian vaults
+```
+
+- If `$1` was given, validate it: `obsidian vault "$1"`. If that errors, report the failure (name typo — show the list from `obsidian vaults`) and stop.
+- If `$1` was omitted and there is exactly one vault, use it silently.
+- If `$1` was omitted and there are multiple vaults, use `AskUserQuestion` to pick one.
+
+## Step 3: Resolve topic → folder + tag conventions
+
+```bash
+obsidian "vault=$VAULT" folders
+```
+
+- If `$2` was given, case-insensitively match it against the folder list (e.g. topic `fraudfront` matches folder `FraudFront`). Use the matching folder.
+- If `$2` was given but nothing matches, use `AskUserQuestion`: create a new top-level folder named after the topic, or pick an existing folder instead.
+- If `$2` was omitted, infer a topic guess from the current repo/project name (e.g. `git rev-parse --show-toplevel` basename, or the project name in `CLAUDE.md`) and propose it via `AskUserQuestion` alongside "pick a different existing folder" and "type a topic".
+
+Once the folder is resolved, learn its formatting conventions rather than inventing your own:
+```bash
+# List existing note filenames in the folder (folders command doesn't list files — use find on the vault path)
+VAULT_PATH=$(obsidian vault "$VAULT" info=path)
+ls "$VAULT_PATH/$FOLDER" 2>/dev/null
+```
+If notes exist, `obsidian "vault=$VAULT" read "<one existing note>"` and match its frontmatter shape (tag names, whether it uses `date`/`status` fields, filename separator style — e.g. em dash + " Design" suffix). If the folder is empty, default to: tags = `[<topic-slug>, design]` plus any specific keyword tag drawn from the note's own title, frontmatter fields `tags`/`date`/`status: draft`.
+
+## Step 4: Build the note
+
+- Title: the first `# ` (H1) heading in `$BODY`, or the first non-empty non-frontmatter line if there's no H1.
+- Filename: match the existing folder's naming convention from Step 3; if none observed, use `<Title>.md`.
+- Frontmatter: the tags/fields resolved in Step 3, `date: <today, YYYY-MM-DD>`, `status: draft`.
+- Body: `$BODY` as-is below the frontmatter (don't re-summarize or truncate — the write script in Step 5 chunks automatically, so there's no size limit to work around here, unlike posting to GitHub).
+
+Stage it with the `Write` tool at a scratch path (`mktemp "${TMPDIR:-/tmp}/obsidian-note-XXXXXX.md"`) — **not** in the vault.
+
+## Step 5: Write through the CLI
+
+Check whether a note already exists at the target path first:
+```bash
+obsidian "vault=$VAULT" read "path=$FOLDER/$FILENAME"
+```
+If it returns real content (not a "not found" error), use `AskUserQuestion`: overwrite, save under a new dated variant (append ` — <date>` to the filename), or abort.
+
+Then write via the dedicated script — **this MUST run unsandboxed** (the `obsidian` CLI connects to the running app over a local socket that the command sandbox blocks and hangs on):
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/obsidian-vault-manager/scripts/write-markdown-to-vault.js" \
+  --vault "$VAULT" \
+  --path "$FOLDER/$FILENAME" \
+  --input "$NOTE_FILE" \
+  --overwrite   # only if Step 5's collision check confirmed overwrite
+```
+The script chunks large notes automatically, retries transient CLI errors, and verifies the write by reading the note back — treat a non-zero exit as a real failure, not a warning. It also warns (on stderr) if the source content contains literal `\n`/`\t` two-character sequences (e.g. a code sample describing escape sequences) — the `obsidian` CLI cannot distinguish these from real newline/tab escapes and will silently convert them, which is a CLI limitation, not something this command can fix. If that warning fires, mention it in your report so the user knows to spot-check that section of the note.
+
+## Step 6: Report
+
+Report to the user:
+- Vault name and note path
+- Tags applied
+- Whether this created a new note or overwrote an existing one
+- Any `\n`/`\t` literal-escape warning from Step 5

--- a/plugins/technical-writer/scripts/discover-spec-content.sh
+++ b/plugins/technical-writer/scripts/discover-spec-content.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# discover-spec-content.sh
+#
+# Discovers the best content source for saving a spec/design doc to Obsidian
+# from the current Claude Code session. Outputs JSON to stdout.
+#
+# Adapted from the workflow plugin's discover-issue-content.sh, stripped of
+# GitHub-specific bits (no gh, no label/repo detection) — this command has no
+# explicit-file argument slot (its two positional args are vault and topic),
+# so the waterfall starts at superpowers specs/plans.
+#
+# Output JSON shape:
+#   {
+#     "source": "superpowers" | "claude-plan" | "summary",
+#     "primary": "/path/to/file.md" | "",
+#     "secondary": "/path/to/file.md" | "",
+#     "candidates": { "specs": [...], "plans": [...] }
+#   }
+#
+# Exit codes:
+#   0 — success (check "source" field for what was found)
+#   1 — not in a git repo
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+# --- Helpers ---
+
+json_output() {
+  local source="$1" primary="$2" secondary="${3:-}" specs_json="${4:-[]}" plans_json="${5:-[]}"
+  jq -n \
+    --arg source "$source" \
+    --arg primary "$primary" \
+    --arg secondary "$secondary" \
+    --argjson specs "$specs_json" \
+    --argjson plans "$plans_json" \
+    '{
+      source: $source,
+      primary: $primary,
+      secondary: $secondary,
+      candidates: { specs: $specs, plans: $plans }
+    }'
+}
+
+# Collect file paths into a JSON array
+files_to_json_array() {
+  local dir="$1"
+  if [[ -d "$dir" ]]; then
+    local files
+    files=$(find "$dir" -maxdepth 1 -name '*.md' -type f 2>/dev/null | sort -r)
+    if [[ -n "$files" ]]; then
+      echo "$files" | jq -R . | jq -s .
+      return
+    fi
+  fi
+  echo "[]"
+}
+
+# --- Pre-checks ---
+
+if ! command -v jq &>/dev/null; then
+  echo '{"error": "jq not installed"}' >&2
+  exit 1
+fi
+
+if [[ -z "$REPO_ROOT" ]]; then
+  echo '{"error": "not in a git repository"}' >&2
+  exit 1
+fi
+
+# --- Waterfall ---
+
+# 1. Superpowers specs/plans
+SPECS_DIR="$REPO_ROOT/docs/superpowers/specs"
+PLANS_DIR="$REPO_ROOT/docs/superpowers/plans"
+
+SPECS_JSON=$(files_to_json_array "$SPECS_DIR")
+PLANS_JSON=$(files_to_json_array "$PLANS_DIR")
+
+SPEC_COUNT=$(echo "$SPECS_JSON" | jq 'length')
+PLAN_COUNT=$(echo "$PLANS_JSON" | jq 'length')
+
+if [[ "$SPEC_COUNT" -gt 0 || "$PLAN_COUNT" -gt 0 ]]; then
+  PRIMARY=""
+  SECONDARY=""
+
+  if [[ "$SPEC_COUNT" -eq 1 ]]; then
+    PRIMARY=$(echo "$SPECS_JSON" | jq -r '.[0]')
+  elif [[ "$SPEC_COUNT" -gt 1 ]]; then
+    # Multiple specs — leave primary empty, let caller disambiguate from candidates
+    PRIMARY=""
+  fi
+
+  if [[ "$PLAN_COUNT" -ge 1 && -n "$PRIMARY" ]]; then
+    # Spec is primary, most recent plan is secondary
+    SECONDARY=$(echo "$PLANS_JSON" | jq -r '.[0]')
+  elif [[ "$SPEC_COUNT" -eq 0 && "$PLAN_COUNT" -eq 1 ]]; then
+    # No specs, single plan is primary
+    PRIMARY=$(echo "$PLANS_JSON" | jq -r '.[0]')
+  elif [[ "$SPEC_COUNT" -eq 0 && "$PLAN_COUNT" -gt 1 ]]; then
+    # No specs, multiple plans — let caller disambiguate
+    PRIMARY=""
+  fi
+
+  json_output "superpowers" "$PRIMARY" "$SECONDARY" "$SPECS_JSON" "$PLANS_JSON"
+  exit 0
+fi
+
+# 2. Claude plan file via session metadata
+#
+# $PPID inside a script points to the intermediate shell, not Claude Code.
+# Instead, find the session file matching the current working directory by
+# scanning all active session files.
+CLAUDE_DIR="$HOME/.claude"
+CURRENT_CWD="$(pwd)"
+SESSION_ID=""
+
+for sf in "$CLAUDE_DIR/sessions/"*.json; do
+  [[ -f "$sf" ]] || continue
+  sf_cwd=$(jq -r '.cwd // empty' "$sf" 2>/dev/null || echo "")
+  if [[ "$sf_cwd" == "$CURRENT_CWD" ]]; then
+    SESSION_ID=$(jq -r '.sessionId // empty' "$sf" 2>/dev/null || echo "")
+    break
+  fi
+done
+
+if [[ -n "$SESSION_ID" ]]; then
+  ENCODED_CWD=$(echo "$CURRENT_CWD" | tr '/.' '-')
+  JSONL="$CLAUDE_DIR/projects/${ENCODED_CWD}/${SESSION_ID}.jsonl"
+
+  if [[ -f "$JSONL" ]]; then
+    SLUG=$(grep -o '"slug":"[^"]*"' "$JSONL" 2>/dev/null | head -1 | cut -d'"' -f4 || echo "")
+
+    if [[ -n "$SLUG" ]]; then
+      PLAN_FILE="$CLAUDE_DIR/plans/${SLUG}.md"
+
+      if [[ -s "$PLAN_FILE" ]]; then
+        json_output "claude-plan" "$PLAN_FILE" "" "[]" "[]"
+        exit 0
+      fi
+    fi
+  fi
+fi
+
+# 3. Nothing found — caller should generate a summary
+json_output "summary" "" "" "[]" "[]"
+exit 0

--- a/plugins/technical-writer/skills/obsidian-vault-manager/SKILL.md
+++ b/plugins/technical-writer/skills/obsidian-vault-manager/SKILL.md
@@ -27,7 +27,7 @@ Before performing vault operations:
 
 ## Overview
 
-**Use `obsidian` for vault operations that touch links or structure.** For creating notes with substantial content (multi-line, frontmatter, etc.), use the `Write` tool directly after locating the vault path — the CLI's `create` command strips multi-line content when `\n` escapes are used.
+**Use `obsidian` for vault operations that touch links or structure.** For **iCloud-synced vaults** (path contains `Mobile Documents` — check with `obsidian vault "<name>" info=path`), the `Write` tool is not reliable: iCloud paths are TCC-protected, so direct filesystem writes can be blocked even with the sandbox disabled — only the Obsidian app (via the CLI) is guaranteed to land. For creating a note with substantial content (multi-line, frontmatter, code blocks), use `scripts/write-markdown-to-vault.js` in this skill — it chunks large payloads under the CLI's ~10KB IPC ceiling, filters banner noise, retries transient errors, and verifies the write by reading the note back. Run it **unsandboxed** (the CLI hangs under the command sandbox). For vaults on ordinary filesystem paths (not iCloud), the `Write` tool works directly and is simpler for one-off notes.
 
 ## Quick Reference
 
@@ -38,7 +38,8 @@ Before performing vault operations:
 | Vault path | `obsidian vault "<name>" info=path` | Path only, good for scripting |
 | List folders | `obsidian "vault=<name>" folders` | Quote vault name if it has spaces |
 | Read note | `obsidian "vault=<name>" read "<note name>"` | Reads by name (fuzzy) |
-| Create note | `obsidian "vault=<name>" create path="folder/name.md" content="$CONTENT"` | Use `printf` to build `$CONTENT` for multi-line |
+| Create note (large/iCloud) | `node scripts/write-markdown-to-vault.js --vault <name> --path <path> --input <file>` | Chunked, retried, verified — run unsandboxed |
+| Create note (small, non-iCloud) | `obsidian "vault=<name>" create path="folder/name.md" content="$CONTENT"` | Use `printf` to build `$CONTENT` for multi-line |
 | Overwrite note | `obsidian "vault=<name>" create path="..." content="$CONTENT" overwrite` | |
 | Append to note | `obsidian "vault=<name>" append path="<path>" content="<text>"` | |
 | Move note | `obsidian "vault=<name>" move path="old.md" newpath="new.md"` | **Auto-updates all links** |
@@ -106,6 +107,8 @@ mv "vault/Random Notes/Design.md" "vault/Projects/Design.md"
 | Using `obsidian-cli` | That's a different npm package — the tool is `obsidian` | Use `obsidian` |
 | Using `--flags` syntax | The CLI uses `key=value` positional args, not `--flags` | Use `key=value` format |
 | `create` with `\n` in double-quoted string | Escapes get stripped, content truncated | Use `printf` to build a `$CONTENT` variable |
+| Using `Write` on an iCloud vault path | TCC can silently block the write even with the sandbox disabled | Use `scripts/write-markdown-to-vault.js` instead |
+| Content over ~10KB in one `create`/`append` call | Silent broken pipe (exit 0, nothing written) or a `NativeImage` error | Use `scripts/write-markdown-to-vault.js` — it chunks automatically |
 | Using `mv` to move notes | Breaks all `[[wiki-links]]` to that note | Use `obsidian move` |
 | Not checking existing note format | Each vault has different tagging/frontmatter conventions | Read an existing note first |
 | Using absolute paths in wiki-links | Breaks when vault moves | Use vault-relative paths |

--- a/plugins/technical-writer/skills/obsidian-vault-manager/scripts/write-markdown-to-vault.js
+++ b/plugins/technical-writer/skills/obsidian-vault-manager/scripts/write-markdown-to-vault.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Write a plain markdown note into an Obsidian vault through the `obsidian`
+ * CLI, chunked to stay under the CLI's IPC payload ceiling, with banner
+ * filtering, transient-error retries, and a read-back verify.
+ *
+ * This is the reliable path for iCloud-synced vaults (paths under
+ * ~/Library/Mobile Documents/iCloud~md~obsidian/Documents/<name>): TCC can
+ * block direct filesystem read/write to that path even with the sandbox
+ * disabled, so a plain `Write` tool call is not guaranteed to land. The
+ * `obsidian` CLI proxies to the running app, which holds the entitlement.
+ * Also works for any other vault.
+ *
+ * Adapted from obsidian-excalidraw's write-to-vault.js (same plugin repo) —
+ * same lessons (payload ceiling, unreliable confirmation line, run
+ * unsandboxed) — simplified for plain markdown: there's no JSON structure to
+ * split on, so the escaped content is chunked at arbitrary byte boundaries
+ * (never inside a `\n`/`\t` escape pair) and every chunk after the first is
+ * appended with `inline` so no extra newline is introduced at the seam.
+ *
+ * CORRECTION vs write-to-vault.js's stated assumption: empirically (CLI
+ * 1.12.7) the CLI does NOT unescape `\\` → `\`. It does a single left-to-right
+ * scan for literal `\n`/`\t` and converts matches to real newline/tab; any
+ * other backslash is left untouched. There is therefore no way to escape a
+ * literal backslash — source text that already contains a literal `\n` or
+ * `\t` (e.g. a code sample describing escape sequences) will be silently
+ * corrupted into a real newline/tab. This script does NOT attempt to double-
+ * escape backslashes (that doesn't help — verified by testing — and only adds
+ * stray characters); it instead warns when this is detected.
+ *
+ * Usage (MUST run unsandboxed — the CLI hangs under the command sandbox):
+ *   node write-markdown-to-vault.js --vault "My Vault" --path "Folder/Note.md" --input note.md [--overwrite]
+ *   cat note.md | node write-markdown-to-vault.js --vault "My Vault" --path "Folder/Note.md"
+ *
+ * Flags:
+ *   --vault <name>      (required) vault name as shown by `obsidian vaults`
+ *   --path  <path>      (required) vault-relative note path, must end in .md
+ *   --input <file>      markdown source (default: stdin)
+ *   --chunk-bytes <n>   max content= payload per call (default 8000; keep well under ~12KB)
+ *   --overwrite         allow replacing an existing note (default: CLI errors if it exists)
+ *   --no-verify         skip the read-back length validation
+ */
+'use strict';
+
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+// ---------------------------------------------------------------- arg parsing
+function parseArgs(argv) {
+  const out = { chunkBytes: 8000, overwrite: false, verify: true };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--vault') out.vault = argv[++i];
+    else if (a === '--path') out.path = argv[++i];
+    else if (a === '--input') out.input = argv[++i];
+    else if (a === '--chunk-bytes') out.chunkBytes = parseInt(argv[++i], 10);
+    else if (a === '--overwrite') out.overwrite = true;
+    else if (a === '--no-verify') out.verify = false;
+    else die(`unknown argument: ${a}`);
+  }
+  if (!out.vault) die('missing --vault');
+  if (!out.path) die('missing --path');
+  if (!out.path.endsWith('.md')) die(`--path must end in .md (got "${out.path}")`);
+  return out;
+}
+
+function die(msg) {
+  console.error(`write-markdown-to-vault: ${msg}`);
+  process.exit(1);
+}
+
+const BANNER = /Loading updated app package|installer is out of date|Checking for update|Latest version is|App is up to date|^\s*Success\.\s*$|^\s*20\d\d-\d\d-\d\d /;
+function filterBanner(s) {
+  // Only drop lines that actually match a banner pattern — NOT blank lines.
+  // Blank lines are semantically meaningful in markdown (paragraph breaks,
+  // spacing around code fences); an earlier `l && ...` truthy filter here
+  // silently ate every blank line in read-back output, producing false
+  // verify mismatches even when the write was byte-perfect.
+  return (s || '').split('\n').filter(l => !BANNER.test(l)).join('\n');
+}
+
+const HARD_ERR = ['Broken pipe', 'write() failed', 'may require a plugin'];
+const TRANSIENT = ['NativeImage']; // intermittent CLI/Electron hiccup — retry
+function sleep(ms) { spawnSync(process.execPath, ['-e', `setTimeout(()=>{}, ${ms})`]); }
+
+// Run one obsidian CLI command, retrying transient errors and timeouts.
+// Returns the banner-filtered output. Hard errors abort. The confirmation
+// line is NOT required (it can be omitted for larger successful payloads) —
+// correctness is gated by the final read-back verify instead.
+function obsidian(args, { timeout = 60000, retries = 3 } = {}) {
+  for (let attempt = 1; ; attempt++) {
+    const r = spawnSync('obsidian', args, { encoding: 'utf8', timeout, maxBuffer: 64 * 1024 * 1024 });
+    if (r.error) {
+      if (r.error.code === 'ENOENT') die('`obsidian` CLI not found on PATH.');
+      if (r.error.code === 'ETIMEDOUT') {
+        if (attempt <= retries) { console.error(`  (timeout, retry ${attempt}/${retries})`); sleep(3000); continue; }
+        die(`CLI timed out (${timeout}ms) after ${retries} retries. Run UNSANDBOXED (the socket hangs under the sandbox); the app may also be wedged — restart Obsidian.`);
+      }
+      die(`CLI spawn error: ${r.error.message}`);
+    }
+    const out = `${filterBanner(r.stdout)}\n${filterBanner(r.stderr)}`.trim();
+    if (TRANSIENT.some(m => out.includes(m)) && attempt <= retries) {
+      console.error(`  (transient CLI error, retry ${attempt}/${retries})`); sleep(2500); continue;
+    }
+    const hit = HARD_ERR.find(m => out.includes(m));
+    if (hit) { console.error(out); die(`CLI error ("${hit}"). Check the vault name, path, and that the payload is under --chunk-bytes.`); }
+    return out;
+  }
+}
+
+// Escape real newline/tab characters into the literal two-char markers the
+// CLI's content= parser expands back into newline/tab.
+//
+// IMPORTANT (empirically verified against CLI 1.12.7, not just inferred from
+// docs): the CLI does a single left-to-right scan for the literal 2-char
+// sequences `\n` / `\t` and converts each to a real newline/tab. It does NOT
+// have a `\\` → `\` unescape pass — a literal backslash is left untouched
+// UNLESS the very next character is 'n' or 't', in which case the pair is
+// consumed as a newline/tab regardless of intent. There is no way to escape
+// a literal backslash for this CLI. Consequence: source content that already
+// contains a literal backslash immediately followed by 'n' or 't' (e.g. a
+// code sample discussing `\n`/`\t` escape sequences, or a Windows path) WILL
+// be silently corrupted into a real newline/tab on write. We warn about this
+// below rather than attempting to "fix" it (there is no fix).
+function escapeForCli(s) {
+  return s.replace(/\n/g, '\\n').replace(/\t/g, '\\t');
+}
+
+function warnAboutLiteralEscapes(raw) {
+  const matches = raw.match(/\\[nt]/g);
+  if (matches && matches.length) {
+    console.error(
+      `write-markdown-to-vault: warning — source contains ${matches.length} literal ` +
+      '"\\n"/"\\t" sequence(s) (e.g. inside a code sample). The obsidian CLI cannot ' +
+      'distinguish these from real newline/tab escapes and WILL convert them to actual ' +
+      'newlines/tabs on write. This is a CLI limitation, not a bug in this script.'
+    );
+  }
+}
+
+// Split an already-escaped string into <= chunkBytes pieces without ever
+// splitting between a backslash and the character it escapes.
+function chunkEscaped(escaped, chunkBytes) {
+  const chunks = [];
+  let i = 0;
+  while (i < escaped.length) {
+    let end = Math.min(i + chunkBytes, escaped.length);
+    if (escaped[end - 1] === '\\' && end < escaped.length) end -= 1;
+    chunks.push(escaped.slice(i, end));
+    i = end;
+  }
+  return chunks;
+}
+
+// ---------------------------------------------------------------- main
+const opts = parseArgs(process.argv.slice(2));
+const raw = opts.input ? fs.readFileSync(opts.input, 'utf8') : fs.readFileSync(0, 'utf8');
+if (!raw.trim()) die('input content is empty');
+warnAboutLiteralEscapes(raw);
+
+const escaped = escapeForCli(raw);
+const chunks = chunkEscaped(escaped, opts.chunkBytes);
+
+const V = `vault=${opts.vault}`;
+const P = `path=${opts.path}`;
+const log = (m) => console.error(m);
+
+log(`write-markdown-to-vault: ${raw.length} bytes, ${chunks.length} chunk(s) → ${opts.vault}:${opts.path}`);
+
+const createArgs = ['create', V, P, `content=${chunks[0]}`];
+if (opts.overwrite) createArgs.push('overwrite');
+obsidian(createArgs);
+log(`  chunk 1/${chunks.length} written (create${opts.overwrite ? ', overwrite' : ''})`);
+
+for (let i = 1; i < chunks.length; i++) {
+  obsidian(['append', V, P, `content=${chunks[i]}`, 'inline']);
+  log(`  chunk ${i + 1}/${chunks.length} written (append, inline)`);
+}
+
+// ---------------------------------------------------------------- verify
+// The per-call confirmation line is unreliable for larger payloads (see
+// write-to-vault.js), so the real success gate is a read-back comparison.
+if (opts.verify) {
+  const back = obsidian(['read', V, P]);
+  // `read` may print its own banner/header noise beyond BANNER — compare by
+  // checking the note's own content is a substring rather than exact match,
+  // since the CLI can wrap output with contextual lines we don't control.
+  if (!back.includes(raw.trim().slice(0, 200)) || !back.trim().endsWith(raw.trim().slice(-200))) {
+    die('verify: read-back content does not match the start/end of the source.\n' +
+        '       The note may have been OPEN in Obsidian (create/append can no-op on open notes)\n' +
+        '       or a chunk was dropped. Close the note or lower --chunk-bytes, then retry.');
+  }
+  log(`  verified: read-back matches source start/end (${raw.length} bytes written)`);
+} else {
+  log('  (verify skipped — pass without --no-verify to confirm the write)');
+}
+
+log('write-markdown-to-vault: done');


### PR DESCRIPTION
## Summary
- Adds `/save-to-obsidian [vault] [topic]` — auto-discovers session content (superpowers spec/plan, Claude plan file, or a generated summary), resolves vault/folder/tag conventions from existing notes, and writes the note.
- Adds `write-markdown-to-vault.js`, a reliable CLI-based writer for iCloud-synced vaults (TCC blocks direct filesystem writes even with the sandbox disabled): chunks large payloads under the CLI's IPC ceiling, filters banner noise, retries transient errors, verifies via read-back.
- Fixes two bugs found while testing the new script live against a real vault: the CLI has no `\\`→`\` unescape (only a `\n`/`\t` scan, so a literal backslash-n in content is always misread as a newline — the script now warns instead of pretending to fix it), and `filterBanner` was silently deleting legitimate blank lines from read-back output, causing false verify failures.
- Updates `obsidian-vault-manager`'s SKILL.md to point at the new script for iCloud vaults instead of the `Write` tool, which isn't reliably able to touch TCC-protected iCloud paths.
- Bumps `technical-writer` to v2.12.0 per repo convention (version bump required for reinstall to pick up changes).

## Test plan
- [x] `node -c write-markdown-to-vault.js` / `bash -n discover-spec-content.sh` — syntax check
- [x] `discover-spec-content.sh` run against this repo (correctly falls to `summary`, no specs/plans dir) and against a repo with multiple specs (correctly surfaces candidates for disambiguation)
- [x] `write-markdown-to-vault.js` run live against a real iCloud vault: >8KB payload forcing multi-chunk create+append, verified byte-identical round-trip via `diff`; isolated backslash-escaping test cases to confirm CLI escape behavior; throwaway test notes cleaned up via `obsidian delete`
- [ ] `/save-to-obsidian` command itself not yet run end-to-end (only its constituent scripts were tested)