### PR TITLE
fix(obsidian-excalidraw): stop filterBanner from eating blank lines

### DIFF
--- a/plugins/obsidian-excalidraw/.claude-plugin/plugin.json
+++ b/plugins/obsidian-excalidraw/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-excalidraw",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Generate and embed Excalidraw diagrams programmatically inside Obsidian vaults",
   "author": {
     "name": "Scott Jungling",

--- a/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/scripts/write-to-vault.js
+++ b/plugins/obsidian-excalidraw/skills/obsidian-excalidraw/scripts/write-to-vault.js
@@ -76,7 +76,13 @@ function die(msg) {
 
 const BANNER = /Loading updated app package|installer is out of date|Checking for update|Latest version is|App is up to date|^\s*Success\.\s*$|^\s*20\d\d-\d\d-\d\d /;
 function filterBanner(s) {
-  return (s || '').split('\n').filter(l => l && !BANNER.test(l)).join('\n');
+  // Only drop lines that actually match a banner pattern — NOT blank lines.
+  // An earlier `l && ...` truthy filter here also silently ate every blank
+  // line, which happened to be harmless for this script's own JSON-parsing
+  // verify step (found while writing a markdown sibling of this script,
+  // where the same filter corrupted read-back comparisons of prose content
+  // with real blank lines) but is a real bug in a general-purpose helper.
+  return (s || '').split('\n').filter(l => !BANNER.test(l)).join('\n');
 }
 
 const HARD_ERR = ['Broken pipe', 'write() failed', 'not found', 'may require a plugin'];


### PR DESCRIPTION
## Summary
- `filterBanner`'s `l && !BANNER.test(l)` filter also dropped every blank line from CLI output, not just banner noise — an unconditional truthy check bundled in alongside the actual banner-pattern check.
- Found while writing a markdown sibling of this script (`write-markdown-to-vault.js` in `technical-writer`, see #28) — the identical filter there was silently deleting legitimate blank lines from read-back output, causing false verify failures on prose content. Harmless in practice for this script's own JSON-parsing verify step (JSON tolerates stray blank lines), but it's the same bug in a general-purpose helper, so fixing it here too rather than letting it sit as a latent trap for a future change.
- Bumps `obsidian-excalidraw` to v1.4.1 per repo convention.

## Test plan
- [x] Isolated unit-style test of the fixed `filterBanner` confirming blank lines are preserved and banner lines are still dropped
- [x] `node -c write-to-vault.js` — syntax check
- [ ] Not re-run against a live diagram write (one-line change, mechanically identical to the fix already validated live in the markdown sibling script)